### PR TITLE
feature request: add raspberry pi 1 builder

### DIFF
--- a/bin/make-raspberry
+++ b/bin/make-raspberry
@@ -1,0 +1,14 @@
+#!/bin/sh
+echo "this is not working yet" && exit 1
+
+
+CONFIG=${1:-config.nix}
+ISO_DIR=$( nix-build \
+  --no-link \
+  '<nixpkgs/nixos>' \
+  -A config.system.build.sdImage \
+  -I nixpkgs=https://github.com/ElvishJerricco/nixpkgs/archive/cross-nixos-aarch64-2018-08-05.tar.gz \
+  -I nixos-config=lib/raspberry.nix \
+  -I nixcfg=${CONFIG}
+)
+echo $ISO_DIR/iso/nixos.iso

--- a/lib/raspberry.nix
+++ b/lib/raspberry.nix
@@ -1,0 +1,42 @@
+{ lib, ... }:
+let
+
+  elvis-jerrico-cross-nixos-aarch64  = builtins.fetchGit {
+    url = https://github.com/ElvishJerricco/cross-nixos-aarch64.git;
+    rev = "c6c93a514344996a48809f728009d9e01f96f6a5";
+  };
+
+in {
+  imports = [
+    <nixcfg>
+    "${elvis-jerrico-cross-nixos-aarch64}/sd-image-aarch64.nix"
+  ];
+
+  security.polkit.enable = false;
+  services.udisks2.enable = false;
+
+  programs.command-not-found.enable = false;
+
+  system.boot.loader.kernelFile = lib.mkForce "Image";
+
+  # installation-device.nix forces this on. But it currently won't
+  # cross build due to w3m
+  services.nixosManual.enable = lib.mkOverride 0 false;
+
+  # installation-device.nix turns this off.
+  systemd.services.sshd.wantedBy = lib.mkOverride 0 ["multi-user.target"];
+
+
+  # todo : change !!!
+  nixpkgs.crossSystem = lib.systems.examples.raspberryPi;
+
+  nix.checkConfig = false;
+
+  networking.wireless.enable = lib.mkForce false;
+
+  nixpkgs.config.allowUnsupportedSystem = true;
+
+  system.stateVersion = "18.03";
+
+}
+


### PR DESCRIPTION
```
checking for getopt... yes
  HOSTLD  tools/fdtgrep
  CC       libkmod/libkmod-list.lo
checking for isalpha... yes
  LD      arch/arm/cpu/built-in.o
  CC      arch/arm/cpu/armv8/cpu.o
cc1: warning: unknown register name: x18
In file included from ./arch/arm/include/asm/bitops.h:193:0,
                 from include/linux/bitops.h:131,
                 from include/common.h:24,
                 from arch/arm/cpu/armv8/cpu.c:13:
include/asm-generic/bitops/__fls.h: In function '__fls':
include/asm-generic/bitops/__fls.h:17:21: warning: left shift count >= width of type [-Wshift-count-overflow]
  if (!(word & (~0ul << 32))) {
                     ^~
include/asm-generic/bitops/__fls.h:19:8: warning: left shift count >= width of type [-Wshift-count-overflow]
   word <<= 32;
        ^~~
include/asm-generic/bitops/__fls.h:22:21: warning: left shift count >= width of type [-Wshift-count-overflow]
  if (!(word & (~0ul << (BITS_PER_LONG-16)))) {
                     ^~
include/asm-generic/bitops/__fls.h:26:21: warning: left shift count >= width of type [-Wshift-count-overflow]
  if (!(word & (~0ul << (BITS_PER_LONG-8)))) {
                     ^~
include/asm-generic/bitops/__fls.h:30:21: warning: left shift count >= width of type [-Wshift-count-overflow]
  if (!(word & (~0ul << (BITS_PER_LONG-4)))) {
                     ^~
include/asm-generic/bitops/__fls.h:34:21: warning: left shift count >= width of type [-Wshift-count-overflow]
  if (!(word & (~0ul << (BITS_PER_LONG-2)))) {
                     ^~
include/asm-generic/bitops/__fls.h:38:21: warning: left shift count >= width of type [-Wshift-count-overflow]
  if (!(word & (~0ul << (BITS_PER_LONG-1))))
                     ^~
In file included from ./arch/arm/include/asm/bitops.h:194:0,
                 from include/linux/bitops.h:131,
                 from include/common.h:24,
                 from arch/arm/cpu/armv8/cpu.c:13:
include/asm-generic/bitops/__ffs.h: In function '__ffs':
include/asm-generic/bitops/__ffs.h:19:8: warning: right shift count >= width of type [-Wshift-count-overflow]
   word >>= 32;
        ^~~
checking for isdigit... yes
{standard input}: Assembler messages:
{standard input}:36: Error: unexpected character `n' in type specifier
{standard input}:36: Error: bad instruction `b.ne 1b'
  CC       libkmod/libkmod-config.lo
make[1]: *** [scripts/Makefile.build:279: arch/arm/cpu/armv8/cpu.o] Error 1
make: *** [Makefile:1383: arch/arm/cpu/armv8] Error 2
builder for '/nix/store/wacnxn75skl859b5w4c6zjlndymjgccx-uboot-rpi_3_defconfig-2018.07-armv6l-unknown-linux-gnueabihf.drv' failed with exit code 2
cannot build derivation '/nix/store/f09nj6f1bp9y3xcp27znqaakvaa543y3-nixos-sd-image-18.09pre-git-x86_64-linux.img-armv6l-unknown-linux-gnueabihf.drv': 1 dependencies couldn't be built
error: build of '/nix/store/f09nj6f1bp9y3xcp27znqaakvaa543y3-nixos-sd-image-18.09pre-git-x86_64-linux.img-armv6l-unknown-linux-gnueabihf.drv' failed
```
on my machine