### PR TITLE
add make-kexec-bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ format | script
 --- | ---
 iso | bin/make-iso
 kexec | bin/make-kexec
+kexec-bundle | bin/make-kexec-bundle
 openstack | bin/make-openstack
 qcow2 | bin/make-qcow
 virtualbox | bin/make-virtualbox

--- a/bin/make-kexec-bundle
+++ b/bin/make-kexec-bundle
@@ -1,0 +1,5 @@
+#!/bin/sh
+CONFIG=${1:-config.nix}
+shift
+BUNDLE=$( nix-build --no-out-link '<nixpkgs/nixos>' -A config.system.build.kexec_bundle -I nixos-config=lib/kexec.nix -I nixcfg=${CONFIG} "$@" )
+echo "$BUNDLE"

--- a/bin/make-kexec-bundle
+++ b/bin/make-kexec-bundle
@@ -1,5 +1,4 @@
 #!/bin/sh
 CONFIG=${1:-config.nix}
 shift
-BUNDLE=$( nix-build --no-out-link '<nixpkgs/nixos>' -A config.system.build.kexec_bundle -I nixos-config=lib/kexec.nix -I nixcfg=${CONFIG} "$@" )
-echo "$BUNDLE"
+nix-build --no-out-link '<nixpkgs/nixos>' -A config.system.build.kexec_bundle -I nixos-config=lib/kexec.nix -I nixcfg=${CONFIG} "$@"

--- a/lib/kexec.nix
+++ b/lib/kexec.nix
@@ -26,12 +26,13 @@ in {
       name = "kexec-nixos";
       text = ''
         #!/bin/sh
+        set -eu
         ARCHIVE=`awk '/^__ARCHIVE_BELOW__/ { print NR + 1; exit 0; }' $0`
 
         tail -n+$ARCHIVE $0 | tar xJ -C /
         /kexec_nixos
 
-        exit 0
+        exit 1
 
         __ARCHIVE_BELOW__
       '';


### PR DESCRIPTION
Now you can build dangerous system-converting executables. Be very careful not to run this on any established systems.

I've used this many times with my own systems, but not yet in this combination.