### PR TITLE
add make-gce: make Google Compute Engine image

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ it echoes the path to a iso image, which you then can flash onto an usb-stick or
 
 we currently have following generators:
 
-format | script
---- | ---
+format | script | description
+--- | --- | ---
+gce | bin/make-gce | Google Compute Image
 iso | bin/make-iso
 kexec | bin/make-kexec
 kexec-bundle | bin/make-kexec-bundle

--- a/bin/make-gce
+++ b/bin/make-gce
@@ -1,0 +1,5 @@
+#!/bin/sh
+CONFIG=${1:-config.nix}
+shift
+out=$(nix-build --no-out-link '<nixpkgs/nixos>' -A config.system.build.googleComputeImage -I nixos-config=lib/gce.nix -I nixcfg=${CONFIG} "$@" )
+echo "$out"/*.tar.gz

--- a/lib/gce.nix
+++ b/lib/gce.nix
@@ -1,0 +1,7 @@
+{ modulesPath, ... }:
+{
+  imports = [
+    "${toString modulesPath}/virtualisation/google-compute-image.nix"
+    <nixcfg>
+  ];
+}


### PR DESCRIPTION
if that gets accepted I will also add a generator for Amazon Machine Images

The `${toString modulesPath}` is on purpose and allows to avoid evaluation issues when the nix evaluation is strict (like on Hydra)