### PR TITLE
lxc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ install-iso | Installer ISO
 iso | ISO
 kexec | kexec tarball (extract to / and run /kexec_nixos)
 kexec-bundle | same as before, but it's just an executable
+lxc | create a tarball which is importable as an lxc container, use together with lxc-metadata
+lxc-metadata | the necessary metadata for the lxc image to start, usage: lxc image import $(nixos-generate -f lxc-metadata) $(nixos-generate -f lxc)
 openstack | qcow2 image for openstack
 cloudstack | qcow2 image for cloudstack
 qcow2 | qcow2 image

--- a/formats/lxc-metadata.nix
+++ b/formats/lxc-metadata.nix
@@ -1,0 +1,18 @@
+{ config, pkgs, modulesPath, ... }:
+{
+  system.build.metadata = pkgs.callPackage <nixpkgs/nixos/lib/make-system-tarball.nix> {
+    contents = [{
+      source = pkgs.writeText "metadata.yaml" ''
+        architecture: x86_64
+        creation_date: 1424284563
+        properties:
+          description: NixOS
+          os: NixOS
+          release: ${config.system.stateVersion}
+      '';
+      target = "/metadata.yaml";
+    }];
+  };
+  formatAttr = "metadata";
+}
+

--- a/formats/lxc.nix
+++ b/formats/lxc.nix
@@ -1,0 +1,22 @@
+{ config, pkgs, lib, modulesPath, ... }: let
+  pkgs2storeContents = l : map (x: { object = x; symlink = "none"; }) l;
+in {
+  imports = [
+    "${toString modulesPath}/virtualisation/lxc-container.nix"
+  ];
+
+  system.build.tarball = lib.mkForce (pkgs.callPackage <nixpkgs/nixos/lib/make-system-tarball.nix> {
+    contents = [];
+    extraArgs = "--owner=0";
+    storeContents = [
+      {
+        object = config.system.build.toplevel + "/init";
+        symlink = "/sbin/init";
+      }
+    ] ++ (pkgs2storeContents [ pkgs.stdenv ]);
+
+    extraCommands = "mkdir -p proc sys dev";
+  });
+
+  formatAttr = "tarball";
+}


### PR DESCRIPTION
should fix: https://github.com/nix-community/nixos-generators/issues/18
run with: `lxc image import $(./nixos-generate -f lxc-metadata) $(./nixos-generate -f lxc)`
shell can be entered with `lxc exec $my-nixos-lxc -- /run/current-system/sw/bin/bash`

stuff to do:
- [ ] get init from /init instead of /sbin/init so we don't need to rebuild the tarball again
- [ ] set PATH somehow so we can run stuff