### PR TITLE
Rename nova to openstack

### DIFF
--- a/formats/openstack.nix
+++ b/formats/openstack.nix
@@ -1,8 +1,8 @@
 { modulesPath, ... }:
 {
   imports = [
-    "${toString modulesPath}/../maintainers/scripts/openstack/nova-image.nix"
+    "${toString modulesPath}/../maintainers/scripts/openstack/openstack-image.nix"
   ];
 
-  formatAttr = "novaImage";
+  formatAttr = "openstackImage";
 }


### PR DESCRIPTION
Since `nova` attributes have been renamed to `openstack` in nixpkgs. See
https://github.com/NixOS/nixpkgs/commit/d190b204f001d1446807f56eed99a73f8b89e244