### PR TITLE
add Vagrant box WIP example

### DIFF
--- a/formats/vagrant.nix
+++ b/formats/vagrant.nix
@@ -1,0 +1,31 @@
+{ pkgs, config, lib, ... }:
+{
+  imports = [
+    ./virtualbox.nix
+    ../profiles/vagrant.nix
+  ];
+
+  config = {
+    formatAttr = lib.mkForce "vagrantImage";
+    system.build.vagrantImage =
+      let
+        metadata = {
+          provider = "virtualbox";
+        };
+      in
+      pkgs.runCommand "vagrant-image" {} ''
+        cp "${config.system.build.virtualBoxOVA}/${config.virtualbox.vmFileName}" image.ova
+
+        cat <<'EOF' > metadata.json
+        ${builtins.toJSON metadata}
+        EOF
+
+        tar czf vagrantbox.tar.gz *
+
+        mkdir $out
+
+        cp vagrantbox.tar.gz $out/vagrant.box
+      '';
+  };
+
+}

--- a/profiles/vagrant.nix
+++ b/profiles/vagrant.nix
@@ -1,0 +1,62 @@
+{ pkgs, ... }:
+{
+  # remove the fsck that runs at startup. It will always fail to run, stopping
+  # your boot until you press *. 
+  boot.initrd.checkJournalingFS = false;
+
+  # Services to enable:
+
+  # Enable the OpenSSH daemon.
+  services.openssh.enable = true;
+
+  # Enable DBus
+  services.dbus.enable    = true;
+
+  # Replace nptd by timesyncd
+  services.timesyncd.enable = true;
+
+  # Packages for Vagrant
+  environment.systemPackages = with pkgs; [
+    findutils
+    gnumake
+    iputils
+    jq
+    nettools
+    netcat
+    nfs-utils
+    rsync
+  ];
+
+  # Creates a "vagrant" users with password-less sudo access
+  users = {
+    extraGroups = [ { name = "vagrant"; } { name = "vboxsf"; } ];
+    extraUsers  = [
+      # Try to avoid ask password
+      { name = "root"; password = "vagrant"; }
+      {
+        description     = "Vagrant User";
+        name            = "vagrant";
+        group           = "vagrant";
+        extraGroups     = [ "users" "vboxsf" "wheel" ];
+        password        = "vagrant";
+        home            = "/home/vagrant";
+        createHome      = true;
+        useDefaultShell = true;
+        openssh.authorizedKeys.keys = [
+          "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+        ];
+      }
+    ];
+  };
+
+  security.sudo.configFile =
+    ''
+      Defaults:root,%wheel env_keep+=LOCALE_ARCHIVE
+      Defaults:root,%wheel env_keep+=NIX_PATH
+      Defaults:root,%wheel env_keep+=TERMINFO_DIRS
+      Defaults env_keep+=SSH_AUTH_SOCK
+      Defaults lecture = never
+      root   ALL=(ALL) SETENV: ALL
+      %wheel ALL=(ALL) NOPASSWD: ALL, SETENV: ALL
+    '';
+}


### PR DESCRIPTION
some things need to be done:

* the output box format needs to be validated.
 https://www.vagrantup.com/docs/boxes/format.html
* integration with the vagrant nix plugin requires some files to exist
in /etc/nixos on the box

testing, testing

I think this is the future, to replace https://github.com/nix-community/nixbox/issues/38. But I don't have VirtualBox installed on my machine. This work would have to be taken over by a pure soul.
