### PR TITLE
Add format sd-aarch64-noinstaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ raw | raw image
 virtualbox | virtualbox VM
 vm | only used as a qemu-kvm runner
 vm-nogui | same as before, but without a GUI
-sd-aarch64 | create sd card for aarch64. For cross compiling use `--system aarch64-linux` and read the cross-compile section.
+sd-aarch64-installer | create an installer sd card for aarch64. For cross compiling use `--system aarch64-linux` and read the cross-compile section.
+sd-aarch64 | Like sd-aarch64-installer, but does not use default installer image config.
 
 ## Usage
 

--- a/formats/sd-aarch64-installer.nix
+++ b/formats/sd-aarch64-installer.nix
@@ -1,0 +1,8 @@
+{ config, ... }:
+{
+  imports = [
+    <nixpkgs/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix>
+  ];
+
+  formatAttr = "sdImage";
+}

--- a/formats/sd-aarch64.nix
+++ b/formats/sd-aarch64.nix
@@ -1,8 +1,51 @@
-{ config, ... }:
-{
+{ config, lib, pkgs, ... }:
+let
+  extlinux-conf-builder =
+    import <nixpkgs/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix> {
+      pkgs = pkgs.buildPackages;
+    };
+
+in {
   imports = [
-    <nixpkgs/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix>
+    <nixpkgs/nixos/modules/installer/cd-dvd/sd-image.nix>
   ];
+
+  boot.loader = {
+    grub.enable = false;
+    generic-extlinux-compatible.enable = true;
+  };
+
+  boot.consoleLogLevel = lib.mkDefault 7;
+
+  # The serial ports listed here are:
+  # - ttyS0: for Tegra (Jetson TX1)
+  # - ttyAMA0: for QEMU's -machine virt
+  # Also increase the amount of CMA to ensure the virtual console on the RPi3 works.
+  boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
+
+  sdImage = {
+    populateBootCommands = let
+      configTxt = pkgs.writeText "config.txt" ''
+        kernel=u-boot-rpi3.bin
+
+        # Boot in 64-bit mode.
+        arm_control=0x200
+
+        # U-Boot used to need this to work, regardless of whether UART is actually used or not.
+        # TODO: check when/if this can be removed.
+        enable_uart=1
+
+        # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
+        # when attempting to show low-voltage or overtemperature warnings.
+        avoid_warnings=1
+      '';
+      in ''
+        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/boot/)
+        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin boot/u-boot-rpi3.bin
+        cp ${configTxt} boot/config.txt
+        ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./boot
+      '';
+  };
 
   formatAttr = "sdImage";
 }


### PR DESCRIPTION
This additional format expression enables for baking a non-installer system config directly into the resulting image file.

In order to do this i basically copied the initial expression from <nixpkgs> and ripped out any installer related things.