### PR TITLE
Extend default/example config to actually work

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -2,4 +2,10 @@
 {
   services.sshd.enable = true;
   services.nginx.enable = true;
+
+  networking.firewall.allowedTCPPorts = [ 80 ];
+  
+  users.users.root.password = "nixos";
+  services.openssh.permitRootLogin = lib.mkDefault "yes";
+  services.mingetty.autologinUser = lib.mkDefault "root";
 }


### PR DESCRIPTION
Now it not only builds but is also usable.

- You can login as root with password "nixos"
- You are logged in automatically on console (like installer)
- You can login as root with SSH
- You can connect to port 80

I have tested it with format "virtualbox" and "install-iso".

It's not best practice to use such insecure password,
but it's probably OK for this example for people to
see that it works.