### PR TITLE
Don't necessarily include pkgs.stdenv in lxc image

### DIFF
--- a/formats/lxc.nix
+++ b/formats/lxc.nix
@@ -13,7 +13,7 @@ in {
         object = config.system.build.toplevel + "/init";
         symlink = "/sbin/init";
       }
-    ] ++ (pkgs2storeContents [ pkgs.stdenv ]);
+    ];
 
     extraCommands = "mkdir -p proc sys dev";
   });


### PR DESCRIPTION
It's not needed for all lxc images, and for those where it is
it can be easily added to the configuration.nix for that image.

This makes for a smaller image, as gcc alone is 140M.