### PR TITLE
Qcow docfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ lxc | create a tarball which is importable as an lxc container, use together wit
 lxc-metadata | the necessary metadata for the lxc image to start, usage: lxc image import $(nixos-generate -f lxc-metadata) $(nixos-generate -f lxc)
 openstack | qcow2 image for openstack
 cloudstack | qcow2 image for cloudstack
-qcow2 | qcow2 image
+qcow | qcow2 image
 raw | raw image
 virtualbox | virtualbox VM
 vm | only used as a qemu-kvm runner


### PR DESCRIPTION
Using `qcow2` as the the current documentation mentions gives:
```
error: file 'format-config' was not found in the Nix search path
```

Using `qcow` works as expected.