### PR TITLE
Add Hyper-V format

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ nix-env -f https://github.com/nix-community/nixos-generators/archive/master.tar.
 
 format | description
 --- | ---
-azure | Microsoft azure image
+azure | Microsoft azure image (Generation 1 / VHD)
 do | Digital Ocean image
-gce | Google Compute Image
+gce | Google Compute image
+hyperv | Hyper-V Image (Generation 2 / VHDX)
 install-iso | Installer ISO
 install-iso-hyperv | Installer ISO with enabled hyper-v support
 iso | ISO

--- a/formats/hyperv.nix
+++ b/formats/hyperv.nix
@@ -1,0 +1,8 @@
+{ modulesPath, ... }:
+{
+  imports = [
+    "${toString modulesPath}/virtualisation/hyperv-image.nix"
+  ];
+
+  formatAttr = "hypervImage";
+}


### PR DESCRIPTION
Follow up to https://github.com/NixOS/nixpkgs/pull/83930

This allows us to create VHDX files for Hyper-V.

Note: The file that is output at the end of this generation is an `img` file.
e.g.
```
[    1.440485] reboot: Power down
/nix/store/bx4132wc00d8dg10krslzh27bjm93sf7-nixos-hyperv-20.09pre226148.0f5ce2fac0c-x86_64-linux/nixos.img
```
~~The VHDX file _is_ located alongside the `img` file, but my guess is that we don't need the `img` file, and that the VHDX file should be printed in its place upon generation.~~

~~Not sure how I should handle this/if there's a format that does anything similar.~~

I updated `hyperv-image.nix` to remove `$baseImage` after the VHDX is created, like the azure image does here:
https://github.com/NixOS/nixpkgs/blob/4a302d1b9aab8c767bdae26a1d5bcc5dbdcb796a/nixos/modules/virtualisation/azure-image.nix#L22-L25.

This is done in https://github.com/NixOS/nixpkgs/pull/88470.
This PR doesn't really need to wait for nixpkgs, since we just import the user's `<nixpkgs>`, anyway.

cc @offlinehacker

___

### A basic configuration imported directly and running in Hyper-V
![image](https://user-images.githubusercontent.com/1847524/82504996-b7721600-9aca-11ea-8f4d-a2aca01ee9c2.png)
