### PR TITLE
add usb kernel module to raw formats; remove use of mkForce

### DIFF
--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -8,7 +8,7 @@
     efiInstallAsRemovable = true;
   };
 
-  system.build.raw = lib.mkForce (import "${toString modulesPath}/../lib/make-disk-image.nix" {
+  system.build.raw = lib.mkOverride 999 (import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     partitionTableType = "efi";
     diskSize = 2048;

--- a/formats/raw.nix
+++ b/formats/raw.nix
@@ -6,10 +6,13 @@
     fsType = "ext4";
   };
 
-  boot.growPartition = true;
-  boot.kernelParams = [ "console=ttyS0" ];
-  boot.loader.grub.device = lib.mkDefault "/dev/vda";
-  boot.loader.timeout = 0;
+  boot = {
+    growPartition = true;
+    kernelParams = [ "console=ttyS0" ];
+    loader.grub.device = "/dev/vda";
+    loader.timeout = 0;
+    initrd.availableKernelModules = [ "uas" ];
+  };
 
 
   system.build.raw = import "${toString modulesPath}/../lib/make-disk-image.nix" {

--- a/formats/raw.nix
+++ b/formats/raw.nix
@@ -9,7 +9,7 @@
   boot = {
     growPartition = true;
     kernelParams = [ "console=ttyS0" ];
-    loader.grub.device = "/dev/vda";
+    loader.grub.device = lib.mkDefault "/dev/vda";
     loader.timeout = 0;
     initrd.availableKernelModules = [ "uas" ];
   };


### PR DESCRIPTION
 - Added the kernel module `uas` which allows to boot the raw formats from a usb stick.
 - Replaced the use of `mkForce` in `raw-efi.nix` with `mkOverride 999` , since `mkForce` might have the unwanted side effect to overwrite ones settings from the configuration.nix.