### PR TITLE
Flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(lorri direnv)"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,24 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1603066386,
+        "narHash": "sha256-BpO5yrRi2oqYaOHwWZBoRlLydOeYm0YhuLG4ISsaSzE=",
+        "path": "/nix/store/6mz8x91y5pbndzfcbiwf3ag8k30k6m00-source",
+        "rev": "5265d49a36bb5a18c85e6817b338b456acc3b8cc",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,12 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1603066386,
-        "narHash": "sha256-BpO5yrRi2oqYaOHwWZBoRlLydOeYm0YhuLG4ISsaSzE=",
-        "path": "/nix/store/6mz8x91y5pbndzfcbiwf3ag8k30k6m00-source",
-        "rev": "5265d49a36bb5a18c85e6817b338b456acc3b8cc",
-        "type": "path"
+        "lastModified": 1603153815,
+        "narHash": "sha256-uCav0CJ0Zm0vbqJiS9NUYD4XZg4Ww9bbsFzcDUzh2+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "007126eef72271480cb7670e19e501a1ad2c1ff2",
+        "type": "github"
       },
       "original": {
         "id": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,17 @@
         installFlags = [ "PREFIX=$(out)" ];
         postFixup = ''
           wrapProgram $out/bin/nixos-generate \
-            --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ jq coreutils findutils nix ])}
+            --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ jq coreutils findutils ])}
         '';
+      };
+
+      # Currently, you need to mark your configurations with makeOverridable in
+      # order to use nixos-generate on them.
+      nixosConfigurations.example = nixpkgs.lib.makeOverridable nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./configuration.nix
+        ];
       };
     });
     defaultPackage = forAllSystems (system: self.packages."${system}".nixos-generators);
@@ -25,16 +34,16 @@
     devShell = forAllSystems (system: let
       pkgs = nixpkgs.legacyPackages."${system}";
     in pkgs.mkShell {
-      buildInputs = with pkgs; [ jq coreutils findutils nix ];
+      buildInputs = with pkgs; [ jq coreutils findutils ];
     });
 
     # Make it runnable with `nix app`
     apps = forAllSystems (system: {
-      nixos-generators = {
+      nixos-generate = {
         type    = "app";
-        program = "${self.packages."${system}".nixos-generators}/bin/nixos-generators";
+        program = "${self.packages."${system}".nixos-generators}/bin/nixos-generate";
       };
     });
-    defaultApp = forAllSystems (system: self.apps."${system}".nixos-generators);
+    defaultApp = forAllSystems (system: self.apps."${system}".nixos-generate);
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "nixos-generators - one config, multiple formats";
+
+  outputs = { self, nixpkgs }: let
+    forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
+  in {
+    # Packages
+    packages = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages."${system}";
+    in {
+      nixos-generators = pkgs.stdenv.mkDerivation {
+        name = "nixos-generators";
+        src = ./.;
+        meta.description = "Collection of image builders";
+        nativeBuildInputs = with pkgs; [ makeWrapper ];
+        installFlags = [ "PREFIX=$(out)" ];
+        postFixup = ''
+          wrapProgram $out/bin/nixos-generate \
+            --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ jq coreutils findutils nix ])}
+        '';
+      };
+    });
+    defaultPackage = forAllSystems (system: self.packages."${system}".nixos-generators);
+
+    devShell = forAllSystems (system: let
+      pkgs = nixpkgs.legacyPackages."${system}";
+    in pkgs.mkShell {
+      buildInputs = with pkgs; [ jq coreutils findutils nix ];
+    });
+
+    # Make it runnable with `nix app`
+    apps = forAllSystems (system: {
+      nixos-generators = {
+        type    = "app";
+        program = "${self.packages."${system}".nixos-generators}/bin/nixos-generators";
+      };
+    });
+    defaultApp = forAllSystems (system: self.apps."${system}".nixos-generators);
+  };
+}

--- a/nixos-generate
+++ b/nixos-generate
@@ -7,6 +7,8 @@ readonly libexec_dir="${0%/*}"
 readonly format_dir=$libexec_dir/formats
 
 configuration=${NIXOS_CONFIG:-$libexec_dir/configuration.nix}
+flake_uri=
+flake_attr=
 format_path=
 target_system=
 cores=
@@ -28,6 +30,8 @@ Options:
 * --help: shows this help
 * -c, --configuration PATH:
     select the nixos configuration to build. Default: $configuration
+* --flake URI:
+    selects the nixos configuration to build, using flake uri like "~/dotfiles#my-config"
 * -f, --format NAME: select one of the pre-determined formats
 * --format-path PATH: pass a custom format
 * --list: list the available built-in formats
@@ -58,6 +62,16 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -c | --configuration)
       configuration=$2
+      shift
+      ;;
+    --flake)
+      # Note: The reason I'm using awk over cut is because cutting with an
+      # out-of-bounds field will return the last in-bound field instead of empty
+      # string.
+      flake="$(echo "$2" | awk -F'#' '{ print $1; }')"
+
+      flake_uri="$(nix flake info --json -- "$flake" | jq -r .url)"
+      flake_attr="$(echo "$2" | awk -F'#' '{ print $2; }')"
       shift
       ;;
     --cores)
@@ -122,10 +136,18 @@ if [[ ! -f $format_path ]]; then
   abort "format file not found: $format_path"
 fi
 
-nix_args+=(
-  -I "nixos-config=$configuration"
-  -I "format-config=$format_path"
-)
+nix_args+=(--argstr formatConfig "$(realpath "$format_path")")
+
+if [[ -z "$flake_uri" ]]; then
+  nix_args+=(
+    -I "nixos-config=$configuration"
+  )
+else
+  nix_args+=(
+    --argstr flakeUri "$flake_uri"
+    --argstr flakeAttr "${flake_attr:-"$(hostname)"}"
+  )
+fi
 
 if [[ -n $target_system ]]; then
   nix_args+=(--argstr system "$target_system")

--- a/nixos-generate
+++ b/nixos-generate
@@ -1,5 +1,4 @@
-#!/usr/bin/env nix-shell
-#! nix-shell -i bash -p jq
+#!/usr/bin/env bash
 set -euo pipefail
 
 ## Configuration

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,3 @@
 (import (builtins.fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
   src = ./.;
-}).defaultNix.default
+}).shellNix.default


### PR DESCRIPTION
**NOTE: I have not tested this on a non-flake system. Kinda just hoping there's a CI that tests this :stuck_out_tongue:** 

I did test it with `nix-shell -p nix`, and that seems to work lovely, which is weird.

You currently have to mark all your nixosSystems with `lib.makeOverridable`. I might send a PR to nixpkgs that runs this by default.

Test it using flakes:

```sh
nix run github:jD91mZM2/nixos-generators/flake -- --help
```