### PR TITLE
allow raw disk size to automatically increment

### DIFF
--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -11,7 +11,7 @@
   system.build.raw = lib.mkOverride 999 (import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     partitionTableType = "efi";
-    diskSize = 2048;
+    diskSize = "auto";
     format = "raw";
   });
 }

--- a/formats/raw.nix
+++ b/formats/raw.nix
@@ -17,7 +17,7 @@
 
   system.build.raw = import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
-    diskSize = 2048;
+    diskSize = "auto";
     format = "raw";
   };
 


### PR DESCRIPTION
As a follow up to #56 and the fix made because of it https://github.com/NixOS/nixpkgs/pull/89331, remove the 2GB size limit on raw disks.