### PR TITLE
Add `--files` flag for copying files

### DIFF
--- a/formats/cloudstack.nix
+++ b/formats/cloudstack.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, files, ... }:
 {
   imports = [
     "${toString modulesPath}/virtualisation/cloudstack-config.nix"
@@ -14,6 +14,7 @@
           imports = [ "${toString modulesPath}/virtualisation/cloudstack-config.nix" ];
         }
       '';
+    contents = files;
   };
 
   formatAttr = "cloudstackImage";

--- a/formats/install-iso-hyperv.nix
+++ b/formats/install-iso-hyperv.nix
@@ -1,8 +1,10 @@
-{ config, lib, modulesPath, ... }:
+{ config, lib, modulesPath, files, ... }:
 {
   imports = [
     "${toString modulesPath}/installer/cd-dvd/installation-cd-base.nix"
   ];
+
+  isoImage.contents = files;
 
   # override installation-cd-base and enable wpa and sshd start at boot
   systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];

--- a/formats/install-iso.nix
+++ b/formats/install-iso.nix
@@ -1,4 +1,4 @@
-{ config, lib, modulesPath, ... }:
+{ config, lib, modulesPath, files, ... }:
 {
   imports = [
     "${toString modulesPath}/installer/cd-dvd/installation-cd-base.nix"
@@ -6,6 +6,8 @@
 
   # for installer
   isoImage.isoName = "nixos.iso";
+
+  isoImage.contents = files;
 
   # override installation-cd-base and enable wpa and sshd start at boot
   systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];

--- a/formats/iso.nix
+++ b/formats/iso.nix
@@ -1,4 +1,4 @@
-{ config, modulesPath, ... }:
+{ config, modulesPath, files, ... }:
 {
   imports = [
     "${toString modulesPath}/installer/cd-dvd/iso-image.nix"
@@ -9,6 +9,8 @@
 
   # USB booting
   isoImage.makeUsbBootable = true;
+
+  isoImage.contents = files;
 
   formatAttr = "isoImage";
   filename = "*.iso";

--- a/formats/kexec.nix
+++ b/formats/kexec.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, modulesPath, ... }: let
+{ config, pkgs, lib, modulesPath, files, ... }: let
 
   clever-tests = builtins.fetchGit {
     url = https://github.com/cleverca22/nix-tests;
@@ -17,7 +17,7 @@ in {
       storeContents = [
         { object = config.system.build.kexec_script; symlink = "/kexec_nixos"; }
       ];
-      contents = [];
+      contents = files;
     };
 
     kexec_tarball_self_extract_script = pkgs.writeTextFile {

--- a/formats/lxc.nix
+++ b/formats/lxc.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, modulesPath, ... }:
+{ config, pkgs, lib, modulesPath, files, ... }:
 
 {
   imports = [
@@ -18,7 +18,7 @@
         source = config.system.build.toplevel + "/init";
         target = "/sbin/init";
       }
-    ];
+    ] ++ files;
 
     extraCommands = "mkdir -p proc sys dev";
   });

--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, files, ... }:
 {
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";
@@ -16,6 +16,7 @@
     inherit lib config pkgs;
     diskSize = 8192;
     format = "qcow2";
+    contents = files;
   };
 
   formatAttr = "qcow";

--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, files, ... }:
 {
   imports = [ ./raw.nix ];
 
@@ -13,5 +13,6 @@
     partitionTableType = "efi";
     diskSize = 2048;
     format = "raw";
+    contents = files;
   });
 }

--- a/formats/raw.nix
+++ b/formats/raw.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, files, ... }:
 {
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";
@@ -14,11 +14,11 @@
     initrd.availableKernelModules = [ "uas" ];
   };
 
-
   system.build.raw = import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     diskSize = 2048;
     format = "raw";
+    contents = files;
   };
 
   formatAttr = "raw";

--- a/formats/sd-aarch64-installer.nix
+++ b/formats/sd-aarch64-installer.nix
@@ -1,8 +1,13 @@
-{ config, modulesPath, ... }:
+{ config, lib, modulesPath, files, ... }:
 {
   imports = [
     "${toString modulesPath}/installer/cd-dvd/sd-image-aarch64.nix"
   ];
+
+  sdImage.populateRootCommands = lib.foldr
+    ({ source, target }: acc: acc + ''mkdir -p "$(dirname ${target})"'' +
+      "\ncp ${source} ${target}\n") ""
+    files;
 
   formatAttr = "sdImage";
 }

--- a/formats/sd-aarch64.nix
+++ b/formats/sd-aarch64.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, files, ... }:
 let
   extlinux-conf-builder =
     import "${toString modulesPath}/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix" {
@@ -47,7 +47,10 @@ in {
     populateRootCommands = ''
       mkdir -p ./files/boot
       ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./files/boot
-    '';
+    '' + lib.foldr
+      ({ source, target }: acc: acc + ''mkdir -p "$(dirname ${target})"'' +
+        "\ncp ${source} ${target}\n") ""
+      files;
   };
 
   formatAttr = "sdImage";

--- a/nixos-generate
+++ b/nixos-generate
@@ -40,9 +40,12 @@ Options:
 * --show-trace: show more detailed nix evaluation location information
 * --system: specify the target system (eg: x86_64-linux)
 * -o, --out-link: specify the outlink location for nix-build
-* --cores : to control the maximum amount of parallelism. (see nix-build documentation)
-* --option : Passed to to nix-build (see nix-build documentation).
-* -I KEY=VALUE: Add a key to the Nix expression search path.
+* --cores: to control the maximum amount of parallelism. (see nix-build documentation)
+* --option: passed to to nix-build (see nix-build documentation).
+* -I KEY=VALUE: add a key to the Nix expression search path.
+* --files:
+    JSON array of objects with properties `source` and `target to specify files
+    to copy into build artifact
 USAGE
 }
 
@@ -120,6 +123,10 @@ while [[ $# -gt 0 ]]; do
     -o | --out-link)
       nix_build_args+=(--out-link "$2")
       has_outlink=true
+      shift
+      ;;
+    --files)
+      nix_args+=(--argstr filesJson "$2")
       shift
       ;;
     *)

--- a/nixos-generate.nix
+++ b/nixos-generate.nix
@@ -6,6 +6,7 @@
 
 , flakeUri ? null
 , flakeAttr ? null
+, filesJson ? "[]"
 }:
 let
   module = { lib, ... }: {
@@ -29,6 +30,9 @@ in
   if flakeUri != null then
     flakeSystem.override (attrs: {
       modules = attrs.modules ++ [ module formatConfig ];
+      extraArgs = {
+        files = builtins.fromJSON filesJson;
+      };
     })
   else
     import "${toString nixpkgs}/nixos/lib/eval-config.nix" {
@@ -38,4 +42,7 @@ in
         formatConfig
         configuration
       ];
+      extraArgs = {
+        files = builtins.fromJSON filesJson;
+      };
     }


### PR DESCRIPTION
Closes #60?

Allows copying of files into build artifacts that support it.

I am not sure that this is the best implementation, but it is fairly straightforward and worked for the couple of formats I tested out with a NixOS flake. Sometimes it is necessary to use `--option sandbox false` to copy files, but that's to be expected.

There's many different ways build artifacts get made, so documenting each type seems difficult. I am open to suggestions on how we could improve this.

Example command:
```bash
nixos-generate \
  -f iso \
  --flake './#mysystem' \
  --files '[{ "source": "'$(realpath ./README.md)'", "target": "/README.md" }]' \
  --option sandbox false
```