### PR TITLE
flake: export formats as nixosModules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,14 @@
   outputs = { self, nixpkgs }: let
     forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
   in {
+
+    # export all generator formats in ./formats
+    nixosModules = nixpkgs.lib.mapAttrs' (file: _: {
+      name = nixpkgs.lib.removeSuffix ".nix" file;
+      # The exported module should include the internal format* options
+      value.imports = [ (./formats + "/${file}") ./format-module.nix ];
+    }) (builtins.readDir ./formats);
+
     # Packages
     packages = forAllSystems (system: let
       pkgs = nixpkgs.legacyPackages."${system}";

--- a/format-module.nix
+++ b/format-module.nix
@@ -1,0 +1,14 @@
+{ lib, ... }: {
+  options = {
+    filename = lib.mkOption {
+      type = lib.types.str;
+      description = "Declare the path of the wanted file in the output directory";
+      default = "*";
+    };
+    formatAttr = lib.mkOption {
+      type = lib.types.str;
+      description = "Declare the default attribute to build";
+    };
+  };
+}
+

--- a/nixos-generate.nix
+++ b/nixos-generate.nix
@@ -8,19 +8,7 @@
 , flakeAttr ? null
 }:
 let
-  module = { lib, ... }: {
-    options = {
-      filename = lib.mkOption {
-        type = lib.types.str;
-        description = "Declare the path of the wanted file in the output directory";
-        default = "*";
-      };
-      formatAttr = lib.mkOption {
-        type = lib.types.str;
-        description = "Declare the default attribute to build";
-      };
-    };
-  };
+  module = import ./format-module.nix;
 
   # Will only get evaluated when used, so no worries
   flake = builtins.getFlake flakeUri;


### PR DESCRIPTION
This project has some really cool modules that I want to make use of. I'd like to do it properly by getting them exported in this flake under `nixosModules`.