### PR TITLE
remove conflicting getty option

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -7,5 +7,4 @@
   
   users.users.root.password = "nixos";
   services.openssh.permitRootLogin = lib.mkDefault "yes";
-  services.mingetty.autologinUser = lib.mkDefault "root";
 }


### PR DESCRIPTION
nixos sets this as "nixos" already