### PR TITLE
Update `cleverca22/nix-tests` to fix kexec on AArch64

### DIFF
--- a/formats/kexec.nix
+++ b/formats/kexec.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, modulesPath, ... }: let
 
   clever-tests = builtins.fetchGit {
-    url = https://github.com/cleverca22/nix-tests;
+    url = "https://github.com/cleverca22/nix-tests";
     rev = "a9a316ad89bfd791df4953c1a8b4e8ed77995a18"; # master on 2021-06-13
   };
 in {

--- a/formats/kexec.nix
+++ b/formats/kexec.nix
@@ -2,7 +2,7 @@
 
   clever-tests = builtins.fetchGit {
     url = https://github.com/cleverca22/nix-tests;
-    rev = "4761ec62c4056f2b1df4d468a1e129b808734221"; #master on 2018-05-20
+    rev = "a9a316ad89bfd791df4953c1a8b4e8ed77995a18"; # master on 2021-06-13
   };
 in {
   imports = [


### PR DESCRIPTION
The old version expected a hardcoded `bzImage` kernel image, but AArch64 uses an uncompressed `Image`. This was fixed in https://github.com/cleverca22/nix-tests/commit/a9a316ad89bfd791df4953c1a8b4e8ed77995a18, so this PR updates to that commit.