### PR TITLE
For module-only consumers, avoid depending on nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "nixlib": {
+      "locked": {
+        "lastModified": 1624148832,
+        "narHash": "sha256-HlXFOXPklqUF2eGPPm8kgfvU2psksLDaVGa2JMnpPTo=",
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "rev": "95c4b09c919abfbadc24386008541db16ba712d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1619285658,
@@ -18,6 +33,7 @@
     },
     "root": {
       "inputs": {
+        "nixlib": "nixlib",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,50 +1,66 @@
 {
   description = "nixos-generators - one config, multiple formats";
 
+  # Lib dependency
+  inputs.nixlib.url = "github:divnix/nixpkgs.lib";
+
+  # Bin dependency
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  outputs = { self, nixpkgs }: let
-    forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
-  in {
+  outputs = { self, nixpkgs, nixlib }:
 
+  # Library modules (depend on nixlib)
+  {
     # export all generator formats in ./formats
-    nixosModules = nixpkgs.lib.mapAttrs' (file: _: {
-      name = nixpkgs.lib.removeSuffix ".nix" file;
+    nixosModules = nixlib.lib.mapAttrs' (file: _: {
+      name = nixlib.lib.removeSuffix ".nix" file;
       # The exported module should include the internal format* options
       value.imports = [ (./formats + "/${file}") ./format-module.nix ];
     }) (builtins.readDir ./formats);
+  }
 
-    # Packages
-    packages = forAllSystems (system: let
-      pkgs = nixpkgs.legacyPackages."${system}";
+  //
+
+
+  # Binary and Devshell outputs (depend on nixpkgs)
+  (
+    let
+       forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
     in {
-      nixos-generators = pkgs.stdenv.mkDerivation {
-        name = "nixos-generators";
-        src = ./.;
-        meta.description = "Collection of image builders";
-        nativeBuildInputs = with pkgs; [ makeWrapper ];
-        installFlags = [ "PREFIX=$(out)" ];
-        postFixup = ''
-          wrapProgram $out/bin/nixos-generate \
-            --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ jq coreutils findutils ])}
-        '';
-      };
-    });
-    defaultPackage = forAllSystems (system: self.packages."${system}".nixos-generators);
 
-    devShell = forAllSystems (system: let
-      pkgs = nixpkgs.legacyPackages."${system}";
-    in pkgs.mkShell {
-      buildInputs = with pkgs; [ jq coreutils findutils ];
-    });
+      packages = forAllSystems (system: let
+        pkgs = nixpkgs.legacyPackages."${system}";
+      in {
+        nixos-generators = pkgs.stdenv.mkDerivation {
+          name = "nixos-generators";
+          src = ./.;
+          meta.description = "Collection of image builders";
+          nativeBuildInputs = with pkgs; [ makeWrapper ];
+          installFlags = [ "PREFIX=$(out)" ];
+          postFixup = ''
+            wrapProgram $out/bin/nixos-generate \
+              --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [ jq coreutils findutils ])}
+          '';
+        };
+      });
 
-    # Make it runnable with `nix app`
-    apps = forAllSystems (system: {
-      nixos-generate = {
-        type    = "app";
-        program = "${self.packages."${system}".nixos-generators}/bin/nixos-generate";
-      };
-    });
-    defaultApp = forAllSystems (system: self.apps."${system}".nixos-generate);
-  };
+      defaultPackage = forAllSystems (system: self.packages."${system}".nixos-generators);
+
+      devShell = forAllSystems (system: let
+        pkgs = nixpkgs.legacyPackages."${system}";
+      in pkgs.mkShell {
+        buildInputs = with pkgs; [ jq coreutils findutils ];
+      });
+
+      # Make it runnable with `nix app`
+      apps = forAllSystems (system: {
+        nixos-generate = {
+          type    = "app";
+          program = "${self.packages."${system}".nixos-generators}/bin/nixos-generate";
+        };
+      });
+
+      defaultApp = forAllSystems (system: self.apps."${system}".nixos-generate);
+    }
+  );
 }


### PR DESCRIPTION
This seems odd, but it works since input dependencies are lazily fetched
that means a downstream repo, that only consumes the modules output
(like for example `divnix/digga`), does never fetch nor instantiate
nixpkgs proper (which would be costly).

This enables `divnix/digga` to continue to _not_ depend on `nixpkgs`
for operation.

(it still depends on `nixpkgs` as a strict development dependency, but
beacause of the black magic which I describe above, no end user
will ever fetch it's depenency on `nixpkgs`.)

So, here, we implement a similar trick to avoid acquiring deps
where they should _not_ be acquired.
