### PR TITLE
Replace deprecated mingetty option with getty

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -7,5 +7,5 @@
   
   users.users.root.password = "nixos";
   services.openssh.permitRootLogin = lib.mkDefault "yes";
-  services.mingetty.autologinUser = lib.mkDefault "root";
+  services.getty.autologinUser = lib.mkDefault "root";
 }


### PR DESCRIPTION
Hello,

I just tried to run `nixos-generate -f lxc' and ran into the following error

```
trace: warning: The option `services.mingetty' defined in `/nix/store/msm51p54fsvnq1h593blkrdffxc3axxx-nixos-generators-1.3.0/share/nixos-generator/configuration.nix' has been renamed to `services.getty'.
```

This was changed in January: see NixOS/nixpkgs#108465

Patching with `substituteInPlace` in `postPatch` fixed this, so I'm pushing the fix upstream. TIL what `getty` is 🚀 .

I've tested the patched nixos-generators using `lxc image import $(nixos-generate -f lxc-metadata) $(nixos-generate -f lxc) --alias nixos` and the resulting container runs fine on chromeos.