### PR TITLE
lxc: use new build system from nixpkgs directly

### DIFF
--- a/formats/lxc-metadata.nix
+++ b/formats/lxc-metadata.nix
@@ -1,18 +1,9 @@
 { config, pkgs, modulesPath, ... }:
+
 {
-  system.build.metadata = pkgs.callPackage "${toString modulesPath}/../lib/make-system-tarball.nix" {
-    contents = [{
-      source = pkgs.writeText "metadata.yaml" ''
-        architecture: x86_64
-        creation_date: 1424284563
-        properties:
-          description: NixOS
-          os: NixOS
-          release: ${config.system.stateVersion}
-      '';
-      target = "/metadata.yaml";
-    }];
-  };
+  imports = [
+    "${toString modulesPath}/virtualisation/lxc-container.nix"
+  ];
 
   formatAttr = "metadata";
   filename = "*/tarball/*.tar.xz";

--- a/formats/lxc.nix
+++ b/formats/lxc.nix
@@ -5,24 +5,6 @@
     "${toString modulesPath}/virtualisation/lxc-container.nix"
   ];
 
-  system.build.tarball = lib.mkForce (pkgs.callPackage "${toString modulesPath}/../lib/make-system-tarball.nix" {
-    extraArgs = "--owner=0";
-    storeContents = [
-      {
-        object = config.system.build.toplevel;
-        symlink = "none";
-      }
-    ];
-    contents = [
-      {
-        source = config.system.build.toplevel + "/init";
-        target = "/sbin/init";
-      }
-    ];
-
-    extraCommands = "mkdir -p proc sys dev";
-  });
-
   formatAttr = "tarball";
   filename = "*/tarball/*.tar.xz";
 }


### PR DESCRIPTION
This replaces the current implementation and directly uses the one from nixpkgs, as is availabie in unstable

Since 21.11 is basically around the corner deperacting 21.05 there shouldn't be too much concern for backwards compatibility