### PR TITLE
qcow: also add kernel drivers

### DIFF
--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -1,5 +1,10 @@
 { config, lib, pkgs, modulesPath, ... }:
 {
+  # for virtio kernel drivers
+  imports = [
+    "${toString modulesPath}/profiles/qemu-guest.nix"
+  ];
+
   fileSystems."/" = {
     device = "/dev/disk/by-label/nixos";
     autoResize = true;


### PR DESCRIPTION
Thoughts? qcow is most likely to be used in a hypervisors and most hypervisors use virtio.