### PR TITLE
qcow: add virtualisation.qemuImage.diskSize option

### DIFF
--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -1,27 +1,41 @@
 { config, lib, pkgs, modulesPath, ... }:
+
+with lib;
+
 {
   # for virtio kernel drivers
   imports = [
     "${toString modulesPath}/profiles/qemu-guest.nix"
   ];
 
-  fileSystems."/" = {
-    device = "/dev/disk/by-label/nixos";
-    autoResize = true;
-    fsType = "ext4";
+  options = {
+    virtualisation.qemuImage.diskSize = mkOption {
+      type = types.int;
+      default = 8192;
+      description = ''
+        Size of disk image in MiB.
+      '';
+    };
   };
 
-  boot.growPartition = true;
-  boot.kernelParams = [ "console=ttyS0" ];
-  boot.loader.grub.device = lib.mkDefault "/dev/vda";
-  boot.loader.timeout = 0;
+  config = {
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      autoResize = true;
+      fsType = "ext4";
+    };
 
+    boot.growPartition = true;
+    boot.kernelParams = [ "console=ttyS0" ];
+    boot.loader.grub.device = lib.mkDefault "/dev/vda";
+    boot.loader.timeout = 0;
 
-  system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" {
-    inherit lib config pkgs;
-    diskSize = 8192;
-    format = "qcow2";
+    system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" {
+      inherit lib config pkgs;
+      diskSize = config.virtualisation.qemuImage.diskSize;
+      format = "qcow2";
+    };
+
+    formatAttr = "qcow";
   };
-
-  formatAttr = "qcow";
 }


### PR DESCRIPTION
~~This is very much a WIP PR, the new diskSize functionality does not even seem to work.~~ I created this PR to get other people's ideas and thoughts on this change,~~while also getting help on making this actually work.~~

I would also like to potentially make an option that will expose such diskSize options to the flake output options.