### PR TITLE
fix: nix-build options

### DIFF
--- a/nixos-generate
+++ b/nixos-generate
@@ -80,7 +80,7 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --option)
-      nix_build_args+=("$1" "$2" "$3")
+      nix_build_args+=("$2" "$3")
       shift 2
       ;;
     -f | --format)


### PR DESCRIPTION
Remove the unnecessary "--option" prefix from nix build options.