### PR TITLE
nixos-generate: use extendModules for flakes

### DIFF
--- a/nixos-generate.nix
+++ b/nixos-generate.nix
@@ -15,9 +15,9 @@ let
   flakeSystem = flake.outputs.packages."${system}".nixosConfigurations."${flakeAttr}" or flake.outputs.nixosConfigurations."${flakeAttr}";
 in
   if flakeUri != null then
-    flakeSystem.override (attrs: {
-      modules = attrs.modules ++ [ module formatConfig ];
-    })
+    flakeSystem.extendModules {
+      modules = [ module formatConfig ];
+    }
   else
     import "${toString nixpkgs}/nixos/lib/eval-config.nix" {
       inherit system;


### PR DESCRIPTION
I think this is a much cleaner solution. It does require nixosSystems built with a version of the module system past this commit: https://github.com/NixOS/nixpkgs/pull/143207. I think thats still much better than requiring `makeOverridable`. 

fixes #110 