### PR TITLE
kexec-bundle: get kexec_tarball from module system

### DIFF
--- a/formats/kexec.nix
+++ b/formats/kexec.nix
@@ -40,7 +40,7 @@ in {
     kexec_bundle = pkgs.runCommand "kexec_bundle" {} ''
       cat \
         ${kexec_tarball_self_extract_script} \
-        ${kexec_tarball}/tarball/nixos-system-${kexec_tarball.system}.tar.xz \
+        ${config.system.build.kexec_tarball}/tarball/nixos-system-${kexec_tarball.system}.tar.xz \
         > $out
       chmod +x $out
     '';


### PR DESCRIPTION
should fix https://github.com/nix-community/nixos-generators/issues/142