### PR TITLE
pass specialArgs through to nixosSystem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,11 +26,11 @@
     #       format = "vmware";
     #   };
     # }
-    nixosGenerate = { pkgs, format,  modules ? [ ] }:
+    nixosGenerate = { pkgs, format,  specialArgs ? { }, modules ? [ ] }:
     let 
       formatModule = builtins.getAttr format nixosModules;
       image = nixpkgs.lib.nixosSystem {
-        inherit pkgs;
+        inherit pkgs specialArgs;
         system = pkgs.system;
         modules = [
           formatModule


### PR DESCRIPTION
This allows passing flake inputs to the underlying configuration ala https://nixos.wiki/wiki/Flakes#Using_nix_flakes_with_NixOS

I'm new to nix so apologies if this isn't the right way to do this.