### PR TITLE
Handle "config.filename" output path that is a symlink to a regular file

### DIFF
--- a/.included.yml
+++ b/.included.yml
@@ -22,6 +22,9 @@ stages:
         - mkdir $uploadPath
     script:
         - nix-shell --command './nixos-generate -f $formats -I nixpkgs=channel:nixos-$nixpkgs_ver' |& tee $uploadPath/build.log
+        # Last line of output should be the path of a regular file (or symlink
+        # to a regular file) in the Nix store.
+        - storePath=$(tail -n 1 $uploadPath/build.log) && test -f "$storePath" && test "/nix/store/${storePath#/nix/store/}" = "$storePath"
         - mv $(realpath result) $uploadPath
     artifacts:
         name: "$uploadPath"

--- a/nixos-generate
+++ b/nixos-generate
@@ -169,7 +169,7 @@ out=$(nix-build "${nix_args[@]}" "${nix_build_args[@]}" -A "config.system.build.
 
 if [[ -z $run ]]; then
   # show the first file, ignoring nix-support
-  find "$out" -wholename "$filename" -type f -print -quit
+  find "$out" -wholename "$filename" -xtype f -print -quit
 else
   runner=$(find "$out"/bin -type l -print -quit)
   exec "$runner"


### PR DESCRIPTION
Some formats (e.g. `vm` and `vm-nogui`) have `config.filename` values that refer to symlinks to regular files rather than regular files, full stop.  This changeset updates the `find` invocation near the end of `nixos-generate` to use `-xtype f` rather than `-type f`, thus catching regular files **and** symlinks to regular files.

Additionally, this changeset updates the GitLab CI configuration to assert that the final line of output from `nixos-generate -f <format> [<args>]` refers to a Nix store path that is a regular file or symlink thereto.

Thank you!