### PR TITLE
docs: fix description for `-o`

### DIFF
--- a/nixos-generate
+++ b/nixos-generate
@@ -41,7 +41,7 @@ Options:
 * --system: specify the target system (eg: x86_64-linux)
 * -o, --out-link: specify the outlink location for nix-build
 * --cores : to control the maximum amount of parallelism. (see nix-build documentation)
-* --option : Passed to to nix-build (see nix-build documentation).
+* --option : Passed to nix-build (see nix-build documentation).
 * -I KEY=VALUE: Add a key to the Nix expression search path.
 USAGE
 }


### PR DESCRIPTION
Just a small change to fix the description of the "-o" option.