### PR TITLE
kexec-bundle: define filename pattern

### DIFF
--- a/formats/kexec-bundle.nix
+++ b/formats/kexec-bundle.nix
@@ -3,4 +3,5 @@
   imports = [ ./kexec.nix ];
 
   formatAttr = lib.mkForce "kexec_bundle";
+  filename = lib.mkForce "*-kexec_bundle";
 }


### PR DESCRIPTION
Cherry-picked from #155.

This PR adds an explicit `filename` attribute definition to [the `kexec-bundle` format](./formats/kexec-bundle.nix), as the `filename` definition "inherited" from [the `kexec` format](./formats/kexec.nix) is not appropriate (does not match any output paths of `kexec-bundle`). 