### PR TITLE
Handle `config.system.build` type change from lazy attrset to submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHARE ?= $(PREFIX)/share/nixos-generator
 
 all:
 
-SOURCES = formats format-module.nix configuration.nix nixos-generate.nix
+SOURCES = formats format-module.nix configuration.nix lib.nix nixos-generate.nix
 
 install:
 	mkdir -p $(PREFIX)/bin $(SHARE)

--- a/formats/kexec.nix
+++ b/formats/kexec.nix
@@ -1,9 +1,11 @@
-{ config, pkgs, lib, modulesPath, ... }: let
+{ config, pkgs, lib, modulesPath, options, ... }: let
 
   clever-tests = builtins.fetchGit {
     url = "https://github.com/cleverca22/nix-tests";
     rev = "a9a316ad89bfd791df4953c1a8b4e8ed77995a18"; # master on 2021-06-13
   };
+
+  inherit (import ../lib.nix { inherit lib options; }) maybe;
 in {
   imports = [
     "${toString modulesPath}/installer/netboot/netboot-minimal.nix"
@@ -13,7 +15,7 @@ in {
   ];
 
   system.build = rec {
-    kexec_tarball = lib.mkForce (pkgs.callPackage "${toString modulesPath}/../lib/make-system-tarball.nix" {
+    kexec_tarball = maybe.mkForce (pkgs.callPackage "${toString modulesPath}/../lib/make-system-tarball.nix" {
       storeContents = [
         { object = config.system.build.kexec_script; symlink = "/kexec_nixos"; }
       ];

--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -1,5 +1,8 @@
-{ config, lib, pkgs, modulesPath, ... }:
-{
+{ config, lib, options, pkgs, modulesPath, ... }:
+
+let
+  inherit (import ../lib.nix { inherit lib options; }) maybe;
+in {
   imports = [ ./raw.nix ];
 
   boot.loader.grub = {
@@ -13,7 +16,7 @@
     fsType = "vfat";
   };
 
-  system.build.raw = lib.mkOverride 99 (import "${toString modulesPath}/../lib/make-disk-image.nix" {
+  system.build.raw = maybe.mkOverride 99 (import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     partitionTableType = "efi";
     diskSize = "auto";

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  options,
+}: let
+  # See https://github.com/NixOS/nixpkgs/commit/ccb85a53b6a496984073227fd8c4d4c58889f421
+  # This commit changed the type of `system.build` from a lazy attribute set to
+  # a submodule.  Prior to this commit, it doesn't make sense to qualify, e.g.
+  # the `system.build.kexec_tarball` definition with `lib.mkForce`, as this
+  # would result in setting the (final/resolved) value of
+  # `system.build.kexec_tarball` to something like:
+  #   {
+  #     _type = "override";
+  #     content = <...>;
+  #     priority = 50;
+  #   }
+  # However, since this commit, `system.build.kexec_tarball` *must* be defined
+  # using `lib.mkForce`; otherwise, Nix bails out with a complaint about
+  # `system.build.kexec_tarball` being defined in multiple locations.
+  systemBuildIsSubmodule = options.system.build.type.name == "submodule";
+
+  optionsLookSane = lib.hasAttrByPath ["system" "build" "type" "name"] options;
+in
+  assert (lib.assertMsg optionsLookSane "`options' must be the NixOS module `options' argument"); {
+    maybe =
+      {
+        mkForce = lib.id;
+        mkOverride = _: lib.id;
+      }
+      // (lib.optionalAttrs systemBuildIsSubmodule {
+        inherit (lib) mkForce mkOverride;
+      });
+  }


### PR DESCRIPTION
Cherry-picked from #155.

Don't use `lib.mkForce` on the `system.build.kexec_tarball` definition when building on a `nixpkgs` version from before [the commit](https://github.com/NixOS/nixpkgs/commit/ccb85a53b6a496984073227fd8c4d4c58889f421) that changed `config.system.build`'s type from a lazy attribute set to a submodule.

Prior to this type change, there is no `system.build.kexec_tarball` option declared, so the NixOS module system does not resolve priorities/overrides in the `config.build.kexec_tarball` definition.

That is, with lib.mkForce, the `config.build.kexec_tarball` definition ends up being something like:

```nix
{
  _type = "override";
  content = <...>;
  priority = 50;
}
```

Removing `lib.mkForce` permits sensibly interpolating `system.build.kexec_tarball` in `system.build.kexec_bundle`'s builder script.

Likewise, no `lib.mkOverride` for `system.build.raw`.

This PR introduces two shim functions defined in `./lib.nix`, `maybe.mkForce` and `maybe.mkOverride`, that try to detect whether `config.system.build` is a submodule and:

1. if so, pass through to `lib.mkForce` or `lib.mkOverride`, and
2. If not, just return the supplied argument as-is.