### PR TITLE
Fix lxc-metadata description in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ kexec | kexec tarball (extract to / and run /kexec_nixos)
 kexec-bundle | same as before, but it's just an executable
 kubevirt | KubeVirt image
 lxc | create a tarball which is importable as an lxc container, use together with lxc-metadata
-lxc-metadata | the necessary metadata for the lxc image to start, usage: lxc image import $(nixos-generate -f lxc-metadata) $(nixos-generate -f lxc)
+lxc-metadata | the necessary metadata for the lxc image to start, usage: `lxc image import $(nixos-generate -f lxc-metadata) $(nixos-generate -f lxc)`
 openstack | qcow2 image for openstack
 proxmox | [VMA](https://pve.proxmox.com/wiki/VMA) file for proxmox
 proxmox-lxc | LXC template for proxmox


### PR DESCRIPTION
GitHub now supports LaTeX rendering in READMEs and the two $ in the description for lxc-metadata caused that field to incorrectly render as LaTeX.