### PR TITLE
nixosGenerate: allow and suggest leaving pkgs set to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ An example `flake.nix` demonstrating this approach is below. `vmware` or
   outputs = { self, nixpkgs, nixos-generators, ... }: {
     packages.x86_64-linux = {
       vmware = nixos-generators.nixosGenerate {
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
+        system = "x86_64-linux";
         modules = [
           # you can include your own nixos configuration here, i.e.
           # ./configuration.nix
@@ -177,7 +177,7 @@ An example `flake.nix` demonstrating this approach is below. `vmware` or
         format = "vmware";
       };
       vbox = nixos-generators.nixosGenerate {
-        pkgs = nixpkgs.legacyPackages.x86_64-linux;
+        system = "x86_64-linux";
         format = "virtualbox";
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -21,17 +21,17 @@
     # example usage in flakes:
     #   outputs = { self, nixpkgs, nixos-generators, ...}: {
     #     vmware = nixos-generators.nixosGenerate {
-    #       pkgs = nixpkgs.legacyPackages.x86_64-linux;
+    #       system = "x86_64-linux";
     #       modules = [./configuration.nix];
     #       format = "vmware";
     #   };
     # }
-    nixosGenerate = { pkgs, format,  specialArgs ? { }, modules ? [ ] }:
+    nixosGenerate = { pkgs ? null, format,  system ? null, specialArgs ? { }, modules ? [ ] }:
     let 
       formatModule = builtins.getAttr format nixosModules;
       image = nixpkgs.lib.nixosSystem {
         inherit pkgs specialArgs;
-        system = pkgs.system;
+        system = if system != null then system else pkgs.system;
         modules = [
           formatModule
         ] ++ modules;


### PR DESCRIPTION
Fixes https://github.com/nix-community/nixos-generators/issues/172

Updating the flake in that issue to follow the new guidance causes both packages in the flake to build successfully.