### PR TITLE
formats/linode: Add support for generating linode images

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ iso | ISO
 kexec | kexec tarball (extract to / and run /kexec_nixos)
 kexec-bundle | same as before, but it's just an executable
 kubevirt | KubeVirt image
+linode | Linode image
 lxc | create a tarball which is importable as an lxc container, use together with lxc-metadata
 lxc-metadata | the necessary metadata for the lxc image to start, usage: `lxc image import $(nixos-generate -f lxc-metadata) $(nixos-generate -f lxc)`
 openstack | qcow2 image for openstack

--- a/formats/linode.nix
+++ b/formats/linode.nix
@@ -1,0 +1,95 @@
+{ config, lib, pkgs, modulesPath, ... }:
+{
+  imports = [
+    "${toString modulesPath}/profiles/qemu-guest.nix"
+  ];
+
+  formatAttr = "linode";
+  filename = "*.img.gz";
+
+  system.build.linode = import "${toString modulesPath}/../lib/make-disk-image.nix" {
+    inherit lib config pkgs;
+    partitionTableType = "none";
+    format = "raw";
+    postVM = ''
+      ${pkgs.pigz}/bin/pigz -9 $out/nixos.img
+    '';
+  };
+
+  # Set up filesystems according to Linode preference:
+  fileSystems."/" = {
+    device = "/dev/sda";
+    fsType = "ext4";
+    autoResize = true;
+  };
+
+  swapDevices = [{ device = "/dev/sdb"; }];
+
+  # Enable LISH and Linode booting w/ GRUB
+  boot = {
+    # Add kernel modules detected by nixos-generate-config:
+    initrd.availableKernelModules = [
+      "virtio_pci"
+      "virtio_scsi"
+      "ahci"
+      "sd_mod"
+    ];
+
+    growPartition = true;
+
+    # Set up LISH serial connection:
+    kernelParams = [ "console=ttyS0,19200n8" ];
+
+    loader = {
+      # Increase timeout to allow LISH connection:
+      timeout = lib.mkForce 10;
+
+      grub = {
+        enable = true;
+        version = 2;
+        forceInstall = true;
+        device = "nodev";
+        fsIdentifier = "label";
+
+        # Allow serial connection for GRUB to be able to use LISH:
+        extraConfig = ''
+          serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1;
+          terminal_input serial;
+          terminal_output serial
+        '';
+
+        # Link /boot/grub2 to /boot/grub:
+        extraInstallCommands = ''
+          ln -fs /boot/grub /boot/grub2
+        '';
+
+        # Remove GRUB splash image:
+        splashImage = null;
+      };
+    };
+  };
+
+  # Hardware option detected by nixos-generate-config:
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+
+  # Install diagnostic tools for Linode support:
+  environment.systemPackages = with pkgs; [
+    inetutils
+    mtr
+    sysstat
+    linode-cli
+  ];
+
+  networking = {
+    enableIPv6 = true;
+    tempAddresses = "disabled";
+    useDHCP = true;
+    usePredictableInterfaceNames = false;
+    interfaces.eth0 = {
+      tempAddress = "disabled";
+      useDHCP = true;
+    };
+  };
+
+  services.qemuGuest.enable = true;
+}


### PR DESCRIPTION
Builds `result/nixos.img.gz` image which can be uploaded and run
directly on Linode without an installation process.

Known working settings when setting up Linode:

Configure two disks:
- Label: /dev/sda   Filesystem: ext4 (from uploaded .img.gz image)
- Label: /dev/sdb   Filesystem: swap

Create configuration:
- VM Mode: Paravirtualization
- Kernel: GRUB 2
- Run Level: Run Default Level
- Memory Limit: Do not set any limits on memory usage
- Block Device Assignment:
- - /dev/sda -> /dev/sda
- - /dev/sdb -> /dev/sdb
- Use custom root: No
- Root device: /dev/sda
- Enable distro helper: No
- Disable updatedb: No
- Enable modules.dep helper: No
- Auto-mount devtmpfs: No
- Auto-configure networking: No

Using information from:
- https://www.linode.com/docs/guides/install-nixos-on-linode/
- https://gist.github.com/nixy/e964240d301e0db513463f11bbb22d26
- https://gist.github.com/nocoolnametom/a359624afce4278f16e2760fe65468cc