### PR TITLE
nixosGenerate: add lib parameter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,13 @@
     #       format = "vmware";
     #   };
     # }
-    nixosGenerate = { pkgs ? null, format,  system ? null, specialArgs ? { }, modules ? [ ] }:
+    nixosGenerate = { pkgs ? null, lib ? nixpkgs.lib, format, system ? null, specialArgs ? { }, modules ? [ ] }:
     let 
       formatModule = builtins.getAttr format nixosModules;
       image = nixpkgs.lib.nixosSystem {
         inherit pkgs specialArgs;
         system = if system != null then system else pkgs.system;
+        lib = if lib != null then lib else pkgs.lib;
         modules = [
           formatModule
         ] ++ modules;


### PR DESCRIPTION
`nixosSystem` does enable to set `lib` which by default uses the [`$NIXPKGS/lib`](https://github.com/NixOS/nixpkgs/tree/7fad01d9d5a3f82081c00fb57918d64145dc904c/lib). I'm using `lib` to extend the standard library with my own functions. While importing the custom functions inside of the NixOS module is always an option, I do use it throughout all of the modules so it will be tedious if I go with that route. So instead, I'm adding the option to do so in `nixosGenerate`.

I tried to make as minimal disruptions as possible with this change. This should successfully build the images without much changes. I also tested the examples (e.g., `vmware` and `vbox` image from the README) and my own images (with the custom `lib`) and both cases successfully built.

The biggest caveat so far is using `nixpkgs.lib` which features [an extended version of the library](https://github.com/NixOS/nixpkgs/blob/7fad01d9d5a3f82081c00fb57918d64145dc904c/flake.nix#L20-L74). Using it as the default value is not the same as importing `$NIXPKGS/lib` or just leaving it alone but it is close enough. There are some alternatives to this such as using [nixpkgs.lib](https://github.com/nix-community/nixpkgs.lib) which this flake is already using so we could use that.