### PR TITLE
Don't hardcode qcow `diskSize`

### DIFF
--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, diskSize, ... }:
+{ config, lib, pkgs, modulesPath, diskSize ? 8192, ... }:
 {
   # for virtio kernel drivers
   imports = [

--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -19,7 +19,7 @@
 
   system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
-    diskSize = 8192;
+    diskSize = 16384;
     format = "qcow2";
   };
 

--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, modulesPath, ... }:
+{ config, lib, pkgs, modulesPath, diskSize, ... }:
 {
   # for virtio kernel drivers
   imports = [
@@ -18,8 +18,7 @@
 
 
   system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" {
-    inherit lib config pkgs;
-    diskSize = 16384;
+    inherit lib config pkgs diskSize;
     format = "qcow2";
   };
 


### PR DESCRIPTION
Allow the `diskSize` to be configurable for the qcow format. Keeps the previously hardcoded value of 8192 as a default for backwards compatibility.