### PR TITLE
raw-efi: Locate ESP by disk label instead of /dev/vda1

### DIFF
--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -12,7 +12,7 @@ in {
   };
 
   fileSystems."/boot" = {
-    device = "/dev/vda1";
+    device = "/dev/disk/by-label/ESP";
     fsType = "vfat";
   };
 

--- a/formats/raw.nix
+++ b/formats/raw.nix
@@ -10,7 +10,7 @@
     growPartition = true;
     kernelParams = [ "console=ttyS0" ];
     loader.grub.device = lib.mkDefault "/dev/vda";
-    loader.timeout = 0;
+    loader.timeout = lib.mkDefault 0;
     initrd.availableKernelModules = [ "uas" ];
   };
 


### PR DESCRIPTION
Locating the ESP via /dev/vda1 fails when booting on hardware.
Also, make the grub timeout configurable on raw + raw-efi.