### PR TITLE
Fix formats/sd*

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,5 @@
+cut_body_after = "" # don't include text from the PR body in the merge commit message
+status = [
+  "build (macos-latest)",
+  "build (ubuntu-latest)"
+]

--- a/formats/sd-aarch64-installer.nix
+++ b/formats/sd-aarch64-installer.nix
@@ -1,7 +1,7 @@
 { config, modulesPath, ... }:
 {
   imports = [
-    "${toString modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+    "${toString modulesPath}/installer/sd-card/sd-image-aarch64-installer.nix"
   ];
 
   formatAttr = "sdImage";

--- a/formats/sd-aarch64.nix
+++ b/formats/sd-aarch64.nix
@@ -1,54 +1,8 @@
 { config, lib, pkgs, modulesPath, ... }:
-let
-  extlinux-conf-builder =
-    import "${toString modulesPath}/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.nix" {
-      pkgs = pkgs.buildPackages;
-    };
-
-in {
+{
   imports = [
-    "${toString modulesPath}/installer/sd-card/sd-image.nix"
+    "${toString modulesPath}/installer/sd-card/sd-image-aarch64.nix"
   ];
-
-  boot.loader = {
-    grub.enable = false;
-    generic-extlinux-compatible.enable = true;
-  };
-
-  boot.consoleLogLevel = lib.mkDefault 7;
-
-  # The serial ports listed here are:
-  # - ttyS0: for Tegra (Jetson TX1)
-  # - ttyAMA0: for QEMU's -machine virt
-  # Also increase the amount of CMA to ensure the virtual console on the RPi3 works.
-  boot.kernelParams = ["cma=32M" "console=ttyS0,115200n8" "console=ttyAMA0,115200n8" "console=tty0"];
-
-  sdImage = {
-    populateFirmwareCommands = let
-      configTxt = pkgs.writeText "config.txt" ''
-        kernel=u-boot-rpi3.bin
-
-        # Boot in 64-bit mode.
-        arm_control=0x200
-
-        # U-Boot used to need this to work, regardless of whether UART is actually used or not.
-        # TODO: check when/if this can be removed.
-        enable_uart=1
-
-        # Prevent the firmware from smashing the framebuffer setup done by the mainline kernel
-        # when attempting to show low-voltage or overtemperature warnings.
-        avoid_warnings=1
-      '';
-      in ''
-        (cd ${pkgs.raspberrypifw}/share/raspberrypi/boot && cp bootcode.bin fixup*.dat start*.elf $NIX_BUILD_TOP/firmware/)
-        cp ${pkgs.ubootRaspberryPi3_64bit}/u-boot.bin firmware/u-boot-rpi3.bin
-        cp ${configTxt} firmware/config.txt
-      '';
-    populateRootCommands = ''
-      mkdir -p ./files/boot
-      ${extlinux-conf-builder} -t 3 -c ${config.system.build.toplevel} -d ./files/boot
-    '';
-  };
 
   formatAttr = "sdImage";
 }


### PR DESCRIPTION
During the [movement](https://github.com/NixOS/nixpkgs/pull/110827) of the nixpkgs module paths for sd*, more than just the cd-dvd -> sd-card was changed. As noted within the [old nixpkgs module location](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/installer/cd-dvd/sd-image-aarch64.nix), the intended change of location was sd-card/sd-image-aarch64-installer, rather than just a path change.

For the non installer version for sd-aarch64, I've updated the version here with the version from nixpkgs, minus the import of profiles/base.nix. This means that the images produced should work on the Pi 4 as well as the Pi 3. Although I have not personally tested on hardware. The removal of the CMA kernel param is deliberate, as 32M is too low for the Pi 4, and that it would need to be either upped to the default for the Pi 4 of 64M, or the option removed and let defaults take care of it.

More information about the motivation of these changes can be seen in this comment https://github.com/nix-community/nixos-generators/issues/168#issuecomment-1365976761.

In regards to a bit of discussion, is it worth having our own copy of the nixpkgs version of sd-aarch64? The only difference I could really tell is that the version in nixos-generators doesn't include profiles/base. In my opinion there's not much of a need for profiles/base to be included, but does it hurt to do so? I'm pretty new to Nix so I'm not fully aware of its features, but as far as I understand it, I don't think there's a way to override what gets imported in an import.