### PR TITLE
Add `aarch64-darwin` support for the `nixos-generators` Nix package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
   # Binary and Devshell outputs (depend on nixpkgs)
   (
     let
-       forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" ];
+       forAllSystems = nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" "aarch64-darwin" ];
     in {
 
       packages = forAllSystems (system: let


### PR DESCRIPTION
As off now, I am getting an error that says that the package's flake has no `aarch64-darwin` attribute :

```
▲ ~/C/infra @ main ✔ nix profile install github:nix-community/nixos-generators/6a5dc1d
error: flake 'github:nix-community/nixos-generators/6a5dc1d' does not provide attribute 'packages.aarch64-darwin.default' or 'defaultPackage.aarch64-darwin'
```

This PR fixes that by adding this missing piece into the `flake.nix`.