### PR TITLE
remove isoName in install-iso

### DIFF
--- a/formats/install-iso.nix
+++ b/formats/install-iso.nix
@@ -4,9 +4,6 @@
     "${toString modulesPath}/installer/cd-dvd/installation-cd-base.nix"
   ];
 
-  # for installer
-  isoImage.isoName = "nixos.iso";
-
   # override installation-cd-base and enable wpa and sshd start at boot
   systemd.services.wpa_supplicant.wantedBy = lib.mkForce [ "multi-user.target" ];
   systemd.services.sshd.wantedBy = lib.mkForce [ "multi-user.target" ];


### PR DESCRIPTION
In unstable nixpkgs using `format = "install-iso"` fails with the following issue:
```
error: The option `isoImage.isoName' has conflicting definition values:
       - In `/nix/store/fwbn98fdngk3rkmz27xp9b8xh56bm39j-source/nixos/modules/installer/cd-dvd/installation-cd-base.nix': "nixos-23.11.20230524.87f9156-aarch64-linux.iso"
       - In `/nix/store/8fy7j2vb38k7lazqnpr0mqmqf64hjrj9-source/formats/install-iso.nix': "nixos.iso"
       Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
```

Removing the `isoImage.isoName` fixes this issue