### PR TITLE
improve all-formats module: support customizing and creating formats + add tests + add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ you can use the `--system` option to create images for other architectures.
 
 An example `flake.nix` demonstrating this approach is below.
 
-images can be built from the same `configuration.nix` by running:
+images can be built from that flake by running:
 
-- `nix build .#vmware` or
-- `nix build .#my-custom-format` or
-- `nix build .#<any-other-format>`
+- `nix build .#nixosConfigurations.my-machine.config.formats.vmware` or
+- `nix build .#nixosConfigurations.my-machine.config.formats.my-custom-format` or
+- `nix build .#nixosConfigurations.my-machine.config.formats.<any-other-format>`
 
 ```nix
 {
@@ -198,10 +198,6 @@ images can be built from the same `configuration.nix` by running:
     nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
       modules = [self.nixosModules.my-machine];
     };
-
-    # optionally re-expose all formats as packages
-    packages.x86_64-linux =
-      self.nixosConfigurations.my-machine.config.formats;
   };
 }
 ```

--- a/checks/test-all-formats-flake/flake.nix
+++ b/checks/test-all-formats-flake/flake.nix
@@ -1,0 +1,58 @@
+/*
+Tests using the all-formats module through a flake.
+- Tests if foramts can be customized.
+- Tests if new foramts can be added
+*/
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixos-generators = {
+      url = "github:nix-community/nixos-generators";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    nixos-generators,
+    ...
+  }: {
+    nixosModules.my-machine = {config, ...}: {
+      imports = [
+        nixos-generators.nixosModules.all-formats
+      ];
+
+      nixpkgs.hostPlatform = "x86_64-linux";
+
+      # customize an existing format
+      formatConfigs.vmware = {config, ...}: {
+        services.openssh.enable = false;
+      };
+
+      # define a new format
+      formatConfigs.my-custom-format = {
+        config,
+        modulesPath,
+        ...
+      }: {
+        imports = ["${toString modulesPath}/installer/cd-dvd/installation-cd-base.nix"];
+        formatAttr = "isoImage";
+        filename = "*.iso";
+        networking.wireless.networks = {
+          # ...
+        };
+      };
+    };
+
+    nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
+      modules = [self.nixosModules.my-machine];
+    };
+
+    checks.x86_64-linux = {
+      test-flake_vmware =
+        self.nixosConfigurations.my-machine.config.formats.vmware;
+      test-flake_my-custom-format =
+        self.nixosConfigurations.my-machine.config.formats.my-custom-format;
+    };
+  };
+}

--- a/checks/test-all-formats.nix
+++ b/checks/test-all-formats.nix
@@ -28,6 +28,6 @@
   testedFormats =
     lib.filterAttrs
     (name: _: ! exclude ? ${name})
-    conf.config.system.formats;
+    conf.config.formats;
 in
   testedFormats

--- a/checks/test-customize-format.nix
+++ b/checks/test-customize-format.nix
@@ -1,0 +1,27 @@
+{
+  nixpkgs ? <nixpkgs>,
+  system ? builtins.currentSystem,
+  lib ? import (nixpkgs + /lib),
+}: let
+  nixosSystem = import (nixpkgs + /nixos/lib/eval-config.nix);
+
+  userModule1 = {...}: {
+    formatConfigs.amazon.amazonImage.name = "xyz";
+  };
+
+  userModule2 = {...}: {
+    formatConfigs.amazon.amazonImage.name = lib.mkForce "custom-name";
+  };
+
+  conf = nixosSystem {
+    inherit system;
+    modules = [
+      ../configuration.nix
+      ../all-formats.nix
+      userModule1
+      userModule2
+    ];
+  };
+in
+  assert lib.hasInfix "custom-name" "${conf.config.formats.amazon}";
+    conf.config.formats.amazon


### PR DESCRIPTION
While the `all-formats.nix` module (introduced via https://github.com/nix-community/nixos-generators/pull/241) allows to import all formats at once, it lacks an interface to customize formats or add formats.

This is fixed by adding the top-level option `formatConfigs` (attrsOf deferredModule).

All format modules created under `config.formatConfigs` are mapped so their outputs are available under `config.formats` which has also been moved to the top-level (previously `config.system.formats`).

Done:
- expose the `all-formats` module via `nixosModules`
- add option `formatConfigs` (pre-populated with all existing formats)
- move option `system.formats` -> `formats`
- add test for customizing a format
- add example to readme
- add test similar to the new readme example ensuring that formats can be customized and created

Open questions:
- should the readme section `Using in a Flake` be removed now, as the new section `Using as a nixos-module` supports all its features and should be simpler to use (no need to call a function for each format etc.)?