### PR TITLE
configuration: get rid of warnings

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -9,6 +9,8 @@
 
   networking.firewall.allowedTCPPorts = [80];
 
+  system.stateVersion = lib.version;
+
   users.users.root.password = "nixos";
   services.openssh.settings.PermitRootLogin = lib.mkDefault "yes";
   services.getty.autologinUser = lib.mkDefault "root";

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
         drvPath
         outPath
         outputName
+        system
         ;
       type = "derivation";
     };


### PR DESCRIPTION
Since we generate whole images we don't have state and can always go with the last.