### PR TITLE
Allow overriding the nixosSystem function.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
       nixosGenerate = {
         pkgs ? null,
         lib ? nixpkgs.lib,
+        nixosSystem ? nixpkgs.lib.nixosSystem,
         format,
         system ? null,
         specialArgs ? {},
@@ -82,7 +83,7 @@
           )
           customFormats;
         formatModule = builtins.getAttr format (self.nixosModules // extraFormats);
-        image = nixpkgs.lib.nixosSystem {
+        image = nixosSystem {
           inherit pkgs specialArgs;
           system =
             if system != null


### PR DESCRIPTION
This is useful to add additional defaults or when nixpkgs was patched and we want to use the patched module sources instead of this specified in the flake inputs.