### PR TITLE
fix: extra install commands require full pathing on linode.nix script

### DIFF
--- a/formats/linode.nix
+++ b/formats/linode.nix
@@ -64,7 +64,7 @@
 
         # Link /boot/grub2 to /boot/grub:
         extraInstallCommands = ''
-          ln -fs /boot/grub /boot/grub2
+          ${pkgs.coreutils}/bin/ln -fs /boot/grub /boot/grub2
         '';
 
         # Remove GRUB splash image:


### PR DESCRIPTION
Very simple fix but enables users to nixos-rebuild switch without failure to find said coreutil.