### PR TITLE
Fix failing azure builds

### DIFF
--- a/formats/azure.nix
+++ b/formats/azure.nix
@@ -4,4 +4,5 @@
   ];
 
   formatAttr = "azureImage";
+  fileExtension = ".vhd";
 }


### PR DESCRIPTION
Been banging my head against a wall for multiple days now trying to debug my [nixos-image](https://github.com/physics-enthusiast/nixos-image) azure builds, which were failing at random for what seemed to be no discernable cause, and I think I finally figured it out. From what I can tell, a file extension must specified in the format definition unless the format derivation produces only one file so that the [find query](https://github.com/nix-community/nixos-generators/blob/13ff43edfb6c2fc0ccb26f4c31a573ff45f02953/all-formats.nix#L36) and subsequent symlink works properly. Due to the presence of what appears to be [hydra metadata](https://github.com/NixOS/nixpkgs/blob/804761c3110e46c209c49fee5cc7addf8b4c62cc/nixos/lib/make-disk-image.nix#L527) created by make-disk-image in $out, there is more than one file created by the inner derivation and hence the result of ```find``` in the ```azure``` format is nondeterministic. This sets the extension to ```.vhd``` for the ```azure``` format. It might also be best to require an extension just to be safe (since an upstream derivation might start creating more files without you noticing), although that's an issue for a different PR.