### PR TITLE
Add disk-size argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,27 @@ image was recently merged in nixpkgs):
 NIX_PATH=nixpkgs=../nixpkgs nixos-generate -f do
 ```
 
+## Setting the disk image size
+
+To specify the size of the generated disk image, use the `--disk-size` argument,
+specifying the size in megabytes. This is currently supported by the following
+formats. If this argument is unspecified it defaults to automatic sizing based
+on the generated NixOS build.
+
+- hyperv
+- proxmox
+- qcow
+- raw-efi
+- raw
+- vm
+- vm-nogui
+- vmware
+
+Example (20GB disk):
+```
+nixos-generate -c <your_config.nix> -f <format> --disk-size 20480
+```
+
 ## Cross Compiling
 
 To cross compile nixos images for other architectures you have to configure

--- a/formats/hyperv.nix
+++ b/formats/hyperv.nix
@@ -1,7 +1,18 @@
-{modulesPath, ...}: {
+{
+  modulesPath,
+  specialArgs,
+  lib,
+  ...
+}: let
+  diskSize = specialArgs.diskSize or "auto";
+in {
   imports = [
     "${toString modulesPath}/virtualisation/hyperv-image.nix"
   ];
+
+  hyperv.baseImageSize =
+    if diskSize == "auto" then "auto"
+    else lib.strings.toIntBase10 diskSize;
 
   formatAttr = "hypervImage";
   fileExtension = ".vhdx";

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -1,7 +1,14 @@
-{modulesPath, ...}: {
+{
+  modulesPath,
+  specialArgs,
+  ...
+}: {
   imports = [
     "${toString modulesPath}/virtualisation/proxmox-image.nix"
   ];
+
+  proxmox.qemuConf.diskSize = specialArgs.diskSize or "auto";
+
   formatAttr = "VMA";
   fileExtension = ".vma.zst";
 }

--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -3,6 +3,7 @@
   lib,
   pkgs,
   modulesPath,
+  specialArgs,
   ...
 }: {
   # for virtio kernel drivers
@@ -29,7 +30,7 @@
 
   system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
-    diskSize = 8192;
+    diskSize = specialArgs.diskSize or "auto";
     format = "qcow2";
     partitionTableType = "hybrid";
   };

--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -4,6 +4,7 @@
   options,
   pkgs,
   modulesPath,
+  specialArgs,
   ...
 }: let
   inherit (import ../lib.nix {inherit lib options;}) maybe;
@@ -24,7 +25,7 @@ in {
   system.build.raw = maybe.mkOverride 99 (import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     partitionTableType = "efi";
-    diskSize = "auto";
+    diskSize = specialArgs.diskSize or "auto";
     format = "raw";
   });
 }

--- a/formats/raw.nix
+++ b/formats/raw.nix
@@ -3,6 +3,7 @@
   lib,
   pkgs,
   modulesPath,
+  specialArgs,
   ...
 }: {
   fileSystems."/" = {
@@ -21,7 +22,7 @@
 
   system.build.raw = import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
-    diskSize = "auto";
+    diskSize = specialArgs.diskSize or "auto";
     format = "raw";
   };
 

--- a/formats/vm.nix
+++ b/formats/vm.nix
@@ -1,7 +1,18 @@
-{modulesPath, ...}: {
+{
+  modulesPath,
+  specialArgs,
+  lib,
+  ...
+}: let
+  diskSize = specialArgs.diskSize or "auto";
+in {
   imports = [
     "${toString modulesPath}/virtualisation/qemu-vm.nix"
   ];
+
+  virtualisation.diskSize =
+    if diskSize == "auto" then null
+    else lib.strings.toIntBase10 diskSize;
 
   formatAttr = "vm";
 }

--- a/formats/vmware.nix
+++ b/formats/vmware.nix
@@ -1,7 +1,18 @@
-{modulesPath, ...}: {
+{
+  modulesPath,
+  specialArgs,
+  lib,
+  ...
+}: let
+  diskSize = specialArgs.diskSize or "auto";
+in {
   imports = [
     "${toString modulesPath}/virtualisation/vmware-image.nix"
   ];
+
+  vmware.baseImageSize =
+    if diskSize == "auto" then "auto"
+    else lib.strings.toIntBase10 diskSize;
 
   formatAttr = "vmwareImage";
   fileExtension = ".vmdk";

--- a/nixos-generate
+++ b/nixos-generate
@@ -79,6 +79,10 @@ while [[ $# -gt 0 ]]; do
       cores=$2
       shift
       ;;
+    --disk-size)
+      nix_build_args+=("--argstr" "diskSize" "$2")
+      shift
+      ;;
     --option)
       nix_build_args+=("$1" "$2" "$3")
       shift 2

--- a/nixos-generate.nix
+++ b/nixos-generate.nix
@@ -2,6 +2,7 @@
   nixpkgs ? <nixpkgs>,
   configuration ? <nixos-config>,
   system ? builtins.currentSystem,
+  diskSize ? "auto",
   formatConfig,
   flakeUri ? null,
   flakeAttr ? null,
@@ -20,6 +21,9 @@ in
   else
     import "${toString nixpkgs}/nixos/lib/eval-config.nix" {
       inherit system;
+      specialArgs = {
+        diskSize = diskSize;
+      };
       modules = [
         module
         formatConfig


### PR DESCRIPTION
Many formats generate an image only large enough for the generated NixOS config. This quickly runs out of space for NixOS servers that are updated over time rather than being redeployed with fresh images.

---

I am still learning Nix and NixOS and am open to feedback on how to improve the PR.