### PR TITLE
nixosGenerate: fix extraFormats value

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -76,10 +76,12 @@
             name: value:
               lib.nameValuePair
               name
-              (value
-                // {
-                  imports = value.imports or [] ++ [./format-module.nix];
-                })
+              {
+                imports = [
+                  value
+                  ./format-module.nix
+                ];
+              }
           )
           customFormats;
         formatModule = builtins.getAttr format (self.nixosModules // extraFormats);


### PR DESCRIPTION
It is expected to be a Nix module where this could be a path, function, or an attribute set.