### PR TITLE
refactor/make pkgs func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.qcow2
 result
 result-*
+.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -116,17 +116,7 @@
           pkgs = nixpkgs.legacyPackages."${system}";
         in rec {
           default = nixos-generate;
-          nixos-generate = pkgs.stdenv.mkDerivation {
-            name = "nixos-generate";
-            src = ./.;
-            meta.description = "Collection of image builders";
-            nativeBuildInputs = with pkgs; [makeWrapper];
-            installFlags = ["PREFIX=$(out)"];
-            postFixup = ''
-              wrapProgram $out/bin/nixos-generate \
-                --prefix PATH : ${pkgs.lib.makeBinPath (with pkgs; [jq coreutils findutils])}
-            '';
-          };
+          nixos-generate = pkgs.callPackage ./package.nix {};
         });
 
         checks =

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,19 @@
+{
+  stdenv,
+  makeWrapper,
+  jq,
+  coreutils,
+  findutils,
+  lib,
+}:
+stdenv.mkDerivation {
+  name = "nixos-generate";
+  src = ./.;
+  meta.description = "Collection of image builders";
+  nativeBuildInputs = [makeWrapper];
+  installFlags = ["PREFIX=$(out)"];
+  postFixup = ''
+    wrapProgram $out/bin/nixos-generate \
+      --prefix PATH : ${lib.makeBinPath [jq coreutils findutils]}
+  '';
+}


### PR DESCRIPTION
- fix: add .direnv to gitignore
- refactor: make nixos-generator + /package.nix callPackage-eable

# Context

Ensuring a minimized closure for nixos-generators binary, while at the same time not being able to use flakes (for reasons that may go too far to explain, here), I need a way to callPackage the executable

# Proposed Solution

- extract into `./packages` -> `callPackage (ng + /package.nix) {}`
