### PR TITLE
nixos-generate: fix "specialArgs: command not found"

### DIFF
--- a/nixos-generate
+++ b/nixos-generate
@@ -42,7 +42,7 @@ Options:
 * -o, --out-link: specify the outlink location for nix-build
 * --cores : to control the maximum amount of parallelism. (see nix-build documentation)
 * --option : Passed to nix-build (see nix-build documentation).
-* --special-arg : Passed to the `specialArgs` variable
+* --special-arg : Passed to the "specialArgs" variable
 * -I KEY=VALUE: Add a key to the Nix expression search path.
 USAGE
 }


### PR DESCRIPTION
The error:
```
$ nixos-generate --help
/nix/store/...-nixos-generate/bin/.nixos-generate-wrapped: line 25: specialArgs: command not found
Usage: /nix/store/...-nixos-generate/bin/.nixos-generate-wrapped [options]
...