### PR TITLE
iso: default to zstd compression

### DIFF
--- a/formats/install-iso.nix
+++ b/formats/install-iso.nix
@@ -12,6 +12,9 @@
   systemd.services.wpa_supplicant.wantedBy = lib.mkForce ["multi-user.target"];
   systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
 
+  # Much faster than xz
+  isoImage.squashfsCompression = lib.mkDefault "zstd";
+
   formatAttr = "isoImage";
   fileExtension = ".iso";
 }

--- a/formats/iso.nix
+++ b/formats/iso.nix
@@ -1,5 +1,5 @@
 {
-  config,
+  lib,
   modulesPath,
   ...
 }: {
@@ -12,6 +12,9 @@
 
   # USB booting
   isoImage.makeUsbBootable = true;
+
+  # Much faster than xz
+  isoImage.squashfsCompression = lib.mkDefault "zstd";
 
   formatAttr = "isoImage";
   fileExtension = ".iso";


### PR DESCRIPTION
For most users of nixos-generate zstd will be the better choice as it will build and boot images much faster. Often users have to rebuild images a couple of times before they are happy with the result. NixOS might be better of with xz as it saves download and storage cost for images.