### PR TITLE
Fix nixosModules example

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Images can be built from that flake by running:
 
     # A single nixos config outputting multiple formats.
     # Alternatively put this in a configuration.nix.
-    nixosModules.my-machine = { config, ... }: {
+    nixosModules.myFormats = { config, ... }: {
       imports = [
         nixos-generators.nixosModules.all-formats
       ];
@@ -271,11 +271,11 @@ Images can be built from that flake by running:
           # ...
         };
       };
+    };
 
-      # the evaluated machine
-      nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
-        modules = [ self.nixosModules.my-machine ];
-      };
+    # a machine consuming the module
+    nixosConfigurations.my-machine = nixpkgs.lib.nixosSystem {
+      modules = [ self.nixosModules.myFormats ];
     };
   };
 }


### PR DESCRIPTION
Previously, it did not compile.  The goal of the section appears to have been to describe how to make a nixosModule that will imbue format magic upon configurations referencing it.  With that in mind, I also changed comments and attribute names to make it more clear that the nixosConfiguration is using the nixosModule rather than integral to it or vice versa.