### PR TITLE
feat: Add `nixosConfig` option to `nixosGenerate`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
         pkgs ? null,
         lib ? nixpkgs.lib,
         nixosSystem ? nixpkgs.lib.nixosSystem,
+        nixosConfig ? { },
         format,
         system ? null,
         specialArgs ? {},
@@ -100,7 +101,7 @@
               formatModule
             ]
             ++ modules;
-        };
+        } // nixosConfig;
       in
         image.config.system.build.${image.config.formatAttr};
     }


### PR DESCRIPTION
WIP! WIP! WIP!

Currently doesn't work, but the idea is for an extra option (but not required) to `nixosGenerate` - a `nixosSystem`, which is then merged with the `image` attrset.