### PR TITLE
Allow to configure `bootSize` in `specialArgs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ on the generated NixOS build.
 - hyperv
 - proxmox
 - qcow
+- qcow-efi
 - raw-efi
 - raw
 - vm
@@ -119,10 +120,10 @@ on the generated NixOS build.
 Example (20GB disk):
 
 ```bash
-nixos-generate -c <your_config.nix> -f <format> --disk-size 20480
+nixos-generate -c <your_config.nix> -f <format> --boot-size 512 --disk-size 20480
 ```
 
-To set the disk size in `flake.nix`, set `diskSize` in the `specialArgs` argument of the `nixosGenerate` function.
+To set the disk size in `flake.nix`, set `diskSize` in the `specialArgs` argument of the `nixosGenerate` function. Similarly, you can also set `bootSize` in the `specialArgs` argument in the same manner, as well as use the `--boot-size` argument to specify the size in megabytes for the `/boot` partition.
 
 ```nix
 {
@@ -158,7 +159,8 @@ To set the disk size in `flake.nix`, set `diskSize` in the `specialArgs` argumen
           system = system;
           specialArgs = {
             pkgs = pkgs;
-            diskSize = 20 * 1024;
+            bootSize = 512;       # 500 MB for /boot
+            diskSize = 20 * 1024; # 20 GB for /
           };
           modules = [
             # Pin nixpkgs to the flake input, so that the packages installed
@@ -317,14 +319,14 @@ multiple custom formats.  `nixosGenerate` will then match against these custom f
           # ./configuration.nix
         ];
         format = "vmware";
-        
+
         # optional arguments:
         # explicit nixpkgs and lib:
         # pkgs = nixpkgs.legacyPackages.x86_64-linux;
         # lib = nixpkgs.legacyPackages.x86_64-linux.lib;
         # additional arguments to pass to modules:
         # specialArgs = { myExtraArg = "foobar"; };
-        
+
         # you can also define your own custom formats
         # customFormats = { "myFormat" = <myFormatModule>; ... };
         # format = "myFormat";

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   modulesPath,
   specialArgs,
   ...
@@ -7,7 +8,11 @@
     "${toString modulesPath}/virtualisation/proxmox-image.nix"
   ];
 
-  proxmox.qemuConf.diskSize = specialArgs.diskSize or "auto";
+  proxmox.qemuConf = {
+    diskSize = specialArgs.diskSize or "auto";
+  } // (lib.optionalAttrs ((builtins.hasAttr "bootSize" specialArgs) && specialArgs.bootSize != null) {
+    bootSize = "${builtins.toString specialArgs.bootSize}M";
+  });
 
   formatAttr = "VMA";
   fileExtension = ".vma.zst";

--- a/formats/qcow-efi.nix
+++ b/formats/qcow-efi.nix
@@ -1,57 +1,48 @@
-{ config, lib, pkgs, modulesPath, ... }:
 {
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  specialArgs,
+  ...
+}: let
+  consoles = [ "ttyS0" ] ++
+    (lib.optional (pkgs.stdenv.hostPlatform.isAarch) "ttyAMA0,115200") ++
+    (lib.optional (pkgs.stdenv.hostPlatform.isRiscV64) "ttySIF0,115200");
+in {
   # for virtio kernel drivers
   imports = [
     "${toString modulesPath}/profiles/qemu-guest.nix"
   ];
 
-  options = {
-    boot = {
-      consoles = lib.mkOption {
-        default = [ "ttyS0" ] ++
-                  (lib.optional (pkgs.stdenv.hostPlatform.isAarch) "ttyAMA0,115200") ++
-                  (lib.optional (pkgs.stdenv.hostPlatform.isRiscV64) "ttySIF0,115200");
-        description = "Kernel console boot flags to pass to boot.kernelParams";
-        example = [ "ttyS2,115200" ];
-      };
-
-      diskSize = lib.mkOption {
-        default = "auto";
-        description = "The disk size in megabytes of the system disk image.";
-        type = with lib.types; oneOf [ ints.positive (enum [ "auto" ])];
-      };
-    };
+  fileSystems."/" = {
+    device = "/dev/disk/by-label/nixos";
+    autoResize = true;
+    fsType = "ext4";
   };
 
-  config = {
-    fileSystems."/" = {
-      device = "/dev/disk/by-label/nixos";
-      autoResize = true;
-      fsType = "ext4";
-    };
-
-    fileSystems."/boot" = {
-      device = "/dev/disk/by-label/ESP";
-      fsType = "vfat";
-    };
-
-    boot.growPartition = true;
-    boot.kernelParams = map (c: "console=${c}") config.boot.consoles;
-    boot.loader.grub.device = "nodev";
-
-    boot.loader.grub.efiSupport = true;
-    boot.loader.grub.efiInstallAsRemovable = true;
-    boot.loader.timeout = 0;
-
-    system.build.qcow-efi = import "${toString modulesPath}/../lib/make-disk-image.nix" {
-      inherit lib config pkgs;
-      diskSize = config.boot.diskSize;
-      format = "qcow2";
-      partitionTableType = "efi";
-    };
-
-    formatAttr = "qcow-efi";
-    fileExtension = ".qcow2";
+  fileSystems."/boot" = {
+    device = "/dev/disk/by-label/ESP";
+    fsType = "vfat";
   };
+
+  boot.growPartition = true;
+  boot.kernelParams = map (c: "console=${c}") consoles;
+  boot.loader.grub.device = "nodev";
+
+  boot.loader.grub.efiSupport = true;
+  boot.loader.grub.efiInstallAsRemovable = true;
+  boot.loader.timeout = 0;
+
+  system.build.qcow-efi = import "${toString modulesPath}/../lib/make-disk-image.nix" ({
+    inherit lib config pkgs;
+    diskSize = specialArgs.diskSize or "auto";
+    format = "qcow2";
+    partitionTableType = "efi";
+  } // (lib.optionalAttrs ((builtins.hasAttr "bootSize" specialArgs) && specialArgs.bootSize != null) {
+    bootSize = "${builtins.toString specialArgs.bootSize}M";
+  }));
+
+  formatAttr = "qcow-efi";
+  fileExtension = ".qcow2";
 }
-

--- a/formats/qcow.nix
+++ b/formats/qcow.nix
@@ -28,12 +28,14 @@
   boot.loader.grub.efiInstallAsRemovable = lib.mkIf (pkgs.stdenv.system != "x86_64-linux") (lib.mkDefault true);
   boot.loader.timeout = 0;
 
-  system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" {
+  system.build.qcow = import "${toString modulesPath}/../lib/make-disk-image.nix" ({
     inherit lib config pkgs;
     diskSize = specialArgs.diskSize or "auto";
     format = "qcow2";
     partitionTableType = "hybrid";
-  };
+  } // (lib.optionalAttrs ((builtins.hasAttr "bootSize" specialArgs) && specialArgs.bootSize != null) {
+    bootSize = "${builtins.toString specialArgs.bootSize}M";
+  }));
 
   formatAttr = "qcow";
   fileExtension = ".qcow2";

--- a/formats/raw-efi.nix
+++ b/formats/raw-efi.nix
@@ -27,5 +27,7 @@ in {
     partitionTableType = "efi";
     diskSize = specialArgs.diskSize or "auto";
     format = "raw";
-  });
+  } // (lib.optionalAttrs ((builtins.hasAttr "bootSize" specialArgs) && specialArgs.bootSize != null) {
+    bootSize = "${builtins.toString specialArgs.bootSize}M";
+  }));
 }

--- a/nixos-generate
+++ b/nixos-generate
@@ -80,6 +80,10 @@ while [[ $# -gt 0 ]]; do
       cores=$2
       shift
       ;;
+    --boot-size)
+      nix_build_args+=("--argstr" "bootSize" "$2")
+      shift
+      ;;
     --disk-size)
       nix_build_args+=("--argstr" "diskSize" "$2")
       shift

--- a/nixos-generate.nix
+++ b/nixos-generate.nix
@@ -2,6 +2,7 @@
   nixpkgs ? <nixpkgs>,
   configuration ? <nixos-config>,
   system ? builtins.currentSystem,
+  bootSize ? null,
   diskSize ? "auto",
   formatConfig,
   flakeUri ? null,
@@ -22,6 +23,7 @@ in
     import "${toString nixpkgs}/nixos/lib/eval-config.nix" {
       inherit system;
       specialArgs = {
+        bootSize = bootSize;
         diskSize = diskSize;
       };
       modules = [


### PR DESCRIPTION
Thanks for `nixos-generators`!

Fixes: #369

This PR allows to configure the `/boot` partition size on those formats that specify one. It also provides the ability to set the flag from the command line with the `--boot-size` parameter that specifies the size of the partition in MB, similar to the `--disk-size` parameter.

This PR also updates the `qcow-efi.nix` format because it was an outlier in the implementation. It defines module options that are not set in any of the machinery closer to the user. All formats are using `specialArgs`, except for `qcow-efi.nix`.

I have seen on https://github.com/nix-community/nixos-generators/pull/204 that this was one of the suggested changes by @Mic92, but I think it's a bit misleading because those options are disconnected from any setting the user can configure.

Having modules in all formats with their options and whatnot would be a cleaner solution than using `specialArgs`, but I'd tackle that refactor as a specific work on its own. In the meantime, I think it's worth having consistency across different format implementations.

All tests are passing locally. I have tested it building a NixOS environment to `qcow-efi` and use it as part of my daily driver, I usually run out of space on my `/boot` partition on the VM I work on and while cleaning up works, having a bigger `/boot` partition helps.