### PR TITLE
Cleanup, De-duplicate with upstream nixpkgs

### DIFF
--- a/formats/docker.nix
+++ b/formats/docker.nix
@@ -7,7 +7,6 @@
     "${toString modulesPath}/virtualisation/docker-image.nix"
   ];
 
-  boot.isContainer = true;
   boot.loader.grub.enable = lib.mkForce false;
   boot.loader.systemd-boot.enable = lib.mkForce false;
   services.journald.console = "/dev/console";

--- a/formats/install-iso-hyperv.nix
+++ b/formats/install-iso-hyperv.nix
@@ -1,17 +1,11 @@
 {
-  config,
   lib,
-  modulesPath,
   ...
 }: {
   imports = [
-    "${toString modulesPath}/installer/cd-dvd/installation-cd-base.nix"
+    ./install-iso.nix
   ];
 
-  # override installation-cd-base and enable wpa and sshd start at boot
-  systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
+  systemd.services.wpa_supplicant.wantedBy = lib.mkOverride 40 [];
   virtualisation.hypervGuest.enable = true;
-
-  formatAttr = "isoImage";
-  fileExtension = ".iso";
 }

--- a/formats/install-iso.nix
+++ b/formats/install-iso.nix
@@ -1,5 +1,4 @@
 {
-  config,
   lib,
   modulesPath,
   ...

--- a/formats/install-iso.nix
+++ b/formats/install-iso.nix
@@ -11,9 +11,6 @@
   systemd.services.wpa_supplicant.wantedBy = lib.mkForce ["multi-user.target"];
   systemd.services.sshd.wantedBy = lib.mkForce ["multi-user.target"];
 
-  # Much faster than xz
-  isoImage.squashfsCompression = lib.mkDefault "zstd";
-
   formatAttr = "isoImage";
   fileExtension = ".iso";
 }

--- a/formats/iso.nix
+++ b/formats/iso.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   modulesPath,
   ...
 }: {
@@ -12,9 +11,6 @@
 
   # USB booting
   isoImage.makeUsbBootable = true;
-
-  # Much faster than xz
-  isoImage.squashfsCompression = lib.mkDefault "zstd";
 
   formatAttr = "isoImage";
   fileExtension = ".iso";

--- a/formats/linode.nix
+++ b/formats/linode.nix
@@ -6,13 +6,13 @@
   ...
 }: {
   imports = [
-    "${toString modulesPath}/profiles/qemu-guest.nix"
+    "${toString modulesPath}/virtualisation/linode-image.nix"
   ];
 
-  formatAttr = "linode";
+  formatAttr = "linodeImage";
   fileExtension = ".img.gz";
 
-  system.build.linode = import "${toString modulesPath}/../lib/make-disk-image.nix" {
+  system.build.linodeImage = import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     partitionTableType = "none";
     format = "raw";
@@ -21,46 +21,13 @@
     '';
   };
 
-  # Set up filesystems according to Linode preference:
-  fileSystems."/" = {
-    device = "/dev/sda";
-    fsType = "ext4";
-    autoResize = true;
-  };
-
-  swapDevices = [{device = "/dev/sdb";}];
-
   # Enable LISH and Linode booting w/ GRUB
   boot = {
-    # Add kernel modules detected by nixos-generate-config:
-    initrd.availableKernelModules = [
-      "virtio_pci"
-      "virtio_scsi"
-      "ahci"
-      "sd_mod"
-    ];
-
     growPartition = true;
 
-    # Set up LISH serial connection:
-    kernelParams = ["console=ttyS0,19200n8"];
-
     loader = {
-      # Increase timeout to allow LISH connection:
-      timeout = lib.mkForce 10;
-
       grub = {
-        enable = true;
-        forceInstall = true;
-        device = "nodev";
         fsIdentifier = "label";
-
-        # Allow serial connection for GRUB to be able to use LISH:
-        extraConfig = ''
-          serial --speed=19200 --unit=0 --word=8 --parity=no --stop=1;
-          terminal_input serial;
-          terminal_output serial
-        '';
 
         # Link /boot/grub2 to /boot/grub:
         extraInstallCommands = ''
@@ -78,17 +45,11 @@
 
   # Install diagnostic tools for Linode support:
   environment.systemPackages = with pkgs; [
-    inetutils
-    mtr
-    sysstat
     linode-cli
   ];
 
   networking = {
     enableIPv6 = true;
-    tempAddresses = "disabled";
-    useDHCP = true;
-    usePredictableInterfaceNames = false;
     interfaces.eth0 = {
       tempAddress = "disabled";
       useDHCP = true;

--- a/formats/linode.nix
+++ b/formats/linode.nix
@@ -12,14 +12,14 @@
   formatAttr = "linodeImage";
   fileExtension = ".img.gz";
 
-  system.build.linodeImage = import "${toString modulesPath}/../lib/make-disk-image.nix" {
+  system.build.linodeImage = lib.mkForce (import "${toString modulesPath}/../lib/make-disk-image.nix" {
     inherit lib config pkgs;
     partitionTableType = "none";
     format = "raw";
     postVM = ''
       ${pkgs.pigz}/bin/pigz -9 $out/nixos.img
     '';
-  };
+  });
 
   # Enable LISH and Linode booting w/ GRUB
   boot = {

--- a/formats/openstack.nix
+++ b/formats/openstack.nix
@@ -1,17 +1,8 @@
 {
   modulesPath,
-  lib,
   ...
 }:
-if lib.pathExists "${toString modulesPath}/../maintainers/scripts/openstack/nova-image.nix"
-then {
-  imports = [
-    "${toString modulesPath}/../maintainers/scripts/openstack/nova-image.nix"
-  ];
-
-  formatAttr = "novaImage";
-}
-else {
+{
   imports = [
     "${toString modulesPath}/../maintainers/scripts/openstack/openstack-image.nix"
   ];


### PR DESCRIPTION
Note: This is based on https://github.com/nix-community/nixos-generators/pull/375, so please begin your review at 1dee94896d61bc31c71bc832523306efd6db5d50 or wait for a merge of the former PR and the following rebase :)

Started to go through the modules and compare them to upstream nixpkgs in order to reuse new upstream modules (linode) and remove attributes which are nowadays a default with the same priority in upstream nixpkgs.