### PR TITLE
Expose Storage Options in proxmox.nix

### DIFF
--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -1,6 +1,7 @@
 {
   modulesPath,
   specialArgs,
+  config,
   ...
 }: {
   imports = [
@@ -8,11 +9,11 @@
   ];
 
   proxmox = {
-    qemuConf.diskSize = specialArgs.diskSize or "auto";
+    qemuConf.diskSize = specialArgs.diskSize or config.proxmox.qemuConf.diskSize.default;
     cloudInit = {
-      enable = specialArgs.enableCloudInit or "auto";
-      defaultStorage = specialArgs.defaultStorage or "auto";
-      device = specialArgs.device or "auto";
+      enable = specialArgs.enableCloudInit or config.proxmox.cloudInit.enableCloudInit.default;
+      defaultStorage = specialArgs.defaultStorage or config.proxmox.cloudInit.defaultStorage.default;
+      device = specialArgs.device or config.proxmox.cloudInit.device.default;
     };
   };
 

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -7,7 +7,14 @@
     "${toString modulesPath}/virtualisation/proxmox-image.nix"
   ];
 
-  proxmox.qemuConf.diskSize = specialArgs.diskSize or "auto";
+  proxmox = {
+    qemuConf.diskSize = specialArgs.diskSize or "auto";
+    cloudInit = {
+      enable = specialArgs.enableCloudInit or "auto";
+      defaultStorage = specialArgs.defaultStorage or "auto";
+      device = specialArgs.device "auto";
+    };
+  };
 
   formatAttr = "VMA";
   fileExtension = ".vma.zst";

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -1,7 +1,6 @@
 {
   modulesPath,
   specialArgs,
-  config,
   ...
 }: {
   imports = [

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -8,11 +8,17 @@
   ];
 
   proxmox = {
-    qemuConf.diskSize = specialArgs.diskSize or "auto";
+    qemuConf = {
+      diskSize = specialArgs.diskSize or "auto";
+
+      # Configuration for the default virtio disk. It can be used as a cue for PVE to autodetect the target storage.
+      # This parameter is required by PVE even if it isn't used.
+      virtio0 = specialArgs.virtio0 or "local-lvm:vm-9999-disk-0";
+    };
     cloudInit = {
-      enable = specialArgs.enableCloudInit or true; 
-      defaultStorage = specialArgs.defaultStorage or "local-lvm";
-      device = specialArgs.device or  "ide2";
+      enable = specialArgs.cloudInitEnable or true;
+      defaultStorage = specialArgs.cloudInitDefaultStorage or "local-lvm";
+      device = specialArgs.cloudInitDevice or "ide2";
     };
   };
 

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -12,7 +12,7 @@
     cloudInit = {
       enable = specialArgs.enableCloudInit or "auto";
       defaultStorage = specialArgs.defaultStorage or "auto";
-      device = specialArgs.device "auto";
+      device = specialArgs.device or "auto";
     };
   };
 

--- a/formats/proxmox.nix
+++ b/formats/proxmox.nix
@@ -9,11 +9,11 @@
   ];
 
   proxmox = {
-    qemuConf.diskSize = specialArgs.diskSize or config.proxmox.qemuConf.diskSize.default;
+    qemuConf.diskSize = specialArgs.diskSize or "auto";
     cloudInit = {
-      enable = specialArgs.enableCloudInit or config.proxmox.cloudInit.enableCloudInit.default;
-      defaultStorage = specialArgs.defaultStorage or config.proxmox.cloudInit.defaultStorage.default;
-      device = specialArgs.device or config.proxmox.cloudInit.device.default;
+      enable = specialArgs.enableCloudInit or true; 
+      defaultStorage = specialArgs.defaultStorage or "local-lvm";
+      device = specialArgs.device or  "ide2";
     };
   };
 


### PR DESCRIPTION
# Feature added

- Exposes the upstream options to configure underlying storage.

# What problem does it solve?

When Proxmox does not have `local-lvm` as a default storage then qmrestore fails.

```qmrestore 
restore vma archive: zstd -q -d -c /root/vzdump-qemu-nixos-24.11.20240921.9357f4f.vma.zst | vma extract -v -r /var/tmp/vzdumptmp906885.fifo - /var/tmp/vzdumptmp906885
CFG: size: 401 name: qemu-server.conf
DEV: dev_id=1 size: 21474836480 devname: drive-virtio0
CTIME: Mon Sep 23 15:15:37 2024
new volume ID is 'local-zfs:vm-9604-cloudinit'
temporary volume 'local-zfs:vm-9604-cloudinit' sucessfuly removed
no lock found trying to remove 'create'  lock
error before or during data restore, some or all disks were not completely restored. VM 9604 state is NOT cleaned up.

TASK ERROR: command 'set -o pipefail && zstd -q -d -c /root/vzdump-qemu-nixos-24.11.20240921.9357f4f.vma.zst | vma extract -v -r /var/tmp/vzdumptmp906885.fifo - /var/tmp/vzdumptmp906885' failed: storage 'local-lvm' is not available on node 'pve'
```

# steps to reproduce

Test setting `virtio0` to a non-existing storage device. For exampl, use the following flake and set the device using the PRs exposed functionality


```nix
 {
  inputs = {
    nixpkgs.url = "nixpkgs/nixos-unstable";
    nixos-generators = {
      url = "github:reinthal/nixos-generators";
      inputs.nixpkgs.follows = "nixpkgs";
    };
  };
  outputs = {
    nixpkgs,
    nixos-generators,
    ...
  }: let
    system = "x86_64-linux";
  in {
    packages.x86_64-linux = {
      proxmox = nixos-generators.nixosGenerate {
        system = "${system}";
        specialArgs = {
          diskSize = "20480";
          virtio0 = "local-zfs:vm-9999-disk-0";
          cloudInitDefaultStorage = "local-zfs";
        };
        modules = [
          ({...}: {nix.registry.nixpkgs.flake = nixpkgs;})
          ./server
        ];
        format = "proxmox";
      };

      proxmox-lxc = nixos-generators.nixosGenerate {
        system = "${system}";
        modules = [
          ({...}: {nix.registry.nixpkgs.flake = nixpkgs;})
          ./server
        ];
        format = "proxmox-lxc";
      };
    };
  };
}

```