### PR TITLE
fix: Make sure the "--disk-size" arg is correctly interpreted as an int by Nix, when an int is provided

### DIFF
--- a/nixos-generate
+++ b/nixos-generate
@@ -58,6 +58,19 @@ abort() {
   exit 1
 }
 
+# TODO: Is there a better name for this?
+fixDiskSizeFormat() {
+  # If the arg is an int, pass it back unchanged:
+  if [[ "$1" =~ ^[0-9][0-9]*$ ]]; then
+    echo "$1"
+    return
+  fi
+
+  # If the arg is _not_ an int, we'll assume it's a string.
+  # Therefore, we'll make sure it's wrapped in quotes, so its eval'd as a string by Nix:
+  echo "\"$1\""
+}
+
 ## Main ##
 
 while [[ $# -gt 0 ]]; do
@@ -81,7 +94,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --disk-size)
-      nix_build_args+=("--argstr" "diskSize" "$2")
+      # Note: make sure integers are not incorrectly interpreted as strings by Nix:
+      nix_build_args+=("--arg" "diskSize" "$(fixDiskSizeFormat "$2")")
       shift
       ;;
     --special-arg)


### PR DESCRIPTION
FIXES: https://github.com/nix-community/nixos-generators/issues/422

When using `--argstr` to pass the `--disk-size` argument through to the `virtualisation.diskSize` option, Nix will always complain that it has been provided a string when it needs an int or the string `auto`.

This fixes for that by using `--arg` to pass the value through to `nix build` for the `virtualisation.diskSize` option instead of `--argstr`, and then wrapping any **non-integer** arg in quotes (where integer is assumed by testing whether the arg contains only numerals) so that non-integer args are evaluated as strings by Nix.

NOTE:
Passing it through with quote-wrapping for strings, rather than throwing an error inside `nixos-generate`, allows for Nixpkgs to check and provide its own errors, as well as hopefully support any future implementation changes.
e.g:

```
% nixos-generate --format vm --disk-size auto

[...]

 error:
       Failed assertions:
       - Setting virtualisation.diskSize to `auto` is not supported by the current image build or vm runner; use an explicit size.
```