### PR TITLE
fix: Pass `--option` to all nix-* commands

### DIFF
--- a/nixos-generate
+++ b/nixos-generate
@@ -41,7 +41,7 @@ Options:
 * --system: specify the target system (eg: x86_64-linux)
 * -o, --out-link: specify the outlink location for nix-build
 * --cores : to control the maximum amount of parallelism. (see nix-build documentation)
-* --option : Passed to nix-build (see nix-build documentation).
+* --option : Passed to Nix commands (see nix-build documentation).
 * --special-arg : Passed to the "specialArgs" variable
 * -I KEY=VALUE: Add a key to the Nix expression search path.
 USAGE
@@ -103,7 +103,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --option)
-      nix_build_args+=("$1" "$2" "$3")
+      nix_args+=("$1" "$2" "$3")
       shift 2
       ;;
     -f | --format)


### PR DESCRIPTION
Previously, options would only be passed to `nix-build`.

Closes #425