### PR TITLE
shell.nix: replace url literal with string url

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-(import (builtins.fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+(import (builtins.fetchTarball "https://github.com/edolstra/flake-compat/archive/master.tar.gz") {
   src = ./.;
 })
 .shellNix


### PR DESCRIPTION
URL literals are deprecated in Lix, and are removed from Nixpkgs for quite a while.